### PR TITLE
fix snakeyaml import

### DIFF
--- a/packages/flutter_tools/gradle/build.gradle.kts
+++ b/packages/flutter_tools/gradle/build.gradle.kts
@@ -31,4 +31,5 @@ dependencies {
     //  * AGP version constants in packages/flutter_tools/lib/src/android/gradle_utils.dart
     //  * AGP version in buildscript block in packages/flutter_tools/gradle/src/main/flutter.groovy
     compileOnly("com.android.tools.build:gradle:7.3.0")
+    implementation("org.yaml:snakeyaml:2.0")
 }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -85,7 +85,6 @@ buildscript {
         //  * AGP version constants in packages/flutter_tools/lib/src/android/gradle_utils.dart
         //  * AGP version in dependencies block in packages/flutter_tools/gradle/build.gradle.kts
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath group: 'org.yaml', name: 'snakeyaml', version: '2.0'
     }
 }
 


### PR DESCRIPTION
Verified this works on mac and windows.

Fixes issue where building android appbundle fails with error:

```
⑆ /Users/bryanoltman/.shorebird/bin/cache/flutter/3612c8dc659dd7866578b19396efcb63cad71bef/bin/flutter build appbundle --release

startup failed:
/Users/bryanoltman/.shorebird/bin/cache/flutter/3612c8dc659dd7866578b19396efcb63cad71bef/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy: 1125: unable to resolve class Yaml
 @ line 1125, column 41.
             def shorebirdYaml = new Yaml()
                                 ^

1 error
```