### PR TITLE
fix: public key bundling

### DIFF
--- a/packages/shorebird_tests/pubspec.yaml
+++ b/packages/shorebird_tests/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   archive: ^3.5.1
   path: ^1.9.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   lints: ^3.0.0

--- a/packages/shorebird_tests/test/android_test.dart
+++ b/packages/shorebird_tests/test/android_test.dart
@@ -58,7 +58,7 @@ void main() {
         },
       );
 
-      group('when passed through the environment variable', () {
+      group('when public key passed through environment variable', () {
         testWithShorebirdProject(
           'correctly changes the app id and adds the public key',
           (projectDirectory) async {

--- a/packages/shorebird_tests/test/android_test.dart
+++ b/packages/shorebird_tests/test/android_test.dart
@@ -15,8 +15,7 @@ void main() {
       testWithShorebirdProject(
         'adds the public key on top of the original file',
         (projectDirectory) async {
-          final originalContent =
-              await projectDirectory.shorebirdFile.readAsString();
+          final originalYaml = projectDirectory.shorebirdYaml;
 
           const base64PublicKey = 'public_123';
           await projectDirectory.runFlutterBuildApk(
@@ -29,10 +28,13 @@ void main() {
               await projectDirectory.getGeneratedShorebirdYaml();
 
           expect(
-            generatedYaml,
-            equals(
-              '${originalContent}patch_public_key: $base64PublicKey\n',
-            ),
+            generatedYaml.keys,
+            containsAll(originalYaml.keys),
+          );
+
+          expect(
+            generatedYaml['patch_public_key'],
+            equals(base64PublicKey),
           );
         },
       );
@@ -52,7 +54,7 @@ void main() {
             flavor: 'internal',
           );
 
-          expect(generatedYaml, contains('app_id: internal_123'));
+          expect(generatedYaml['app_id'], equals('internal_123'));
         },
       );
 
@@ -76,10 +78,10 @@ void main() {
               flavor: 'internal',
             );
 
-            expect(generatedYaml, contains('app_id: internal_123'));
+            expect(generatedYaml['app_id'], equals('internal_123'));
             expect(
-              generatedYaml,
-              contains('patch_public_key: $base64PublicKey'),
+              generatedYaml['patch_public_key'],
+              equals(base64PublicKey),
             );
           },
         );

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -39,13 +39,6 @@ Future<ProcessResult> _runFlutterCommand(
   );
 }
 
-Future<void> _flutterUpgrade() async {
-  await _runFlutterCommand(
-    ['upgrade'],
-    workingDirectory: Directory.current,
-  );
-}
-
 Future<void> _createFlutterProject(Directory projectDirectory) async {
   final result = await _runFlutterCommand(
     ['create', '--empty', '.'],
@@ -62,7 +55,6 @@ Future<void> testWithShorebirdProject(String name,
   test(
     name,
     () async {
-      await _flutterUpgrade();
       final parentDirectory = Directory.systemTemp.createTempSync();
       final projectDirectory = Directory(
         path.join(

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 /// This will be the path to the flutter binary housed in this flutter repository.
 ///
@@ -102,6 +103,9 @@ extension ShorebirdProjectDirectoryOnDirectory on Directory {
         path.join(this.path, 'shorebird.yaml'),
       );
 
+  YamlMap get shorebirdYaml =>
+      loadYaml(shorebirdFile.readAsStringSync()) as YamlMap;
+
   File get appGradleFile => File(
         path.join(this.path, 'android', 'app', 'build.gradle'),
       );
@@ -184,14 +188,14 @@ $flavors
         ),
       );
 
-  Future<String> getGeneratedShorebirdYaml({String? flavor}) async {
+  Future<YamlMap> getGeneratedShorebirdYaml({String? flavor}) async {
     final decodedBytes =
         ZipDecoder().decodeBytes(apkFile(flavor: flavor).readAsBytesSync());
 
     await extractArchiveToDisk(
         decodedBytes, path.join(this.path, 'apk-extracted'));
 
-    return File(
+    final raw = File(
       path.join(
         this.path,
         'apk-extracted',
@@ -200,5 +204,6 @@ $flavors
         'shorebird.yaml',
       ),
     ).readAsStringSync();
+    return loadYaml(raw) as YamlMap;
   }
 }

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -39,6 +39,13 @@ Future<ProcessResult> _runFlutterCommand(
   );
 }
 
+Future<void> _flutterUpgrade() async {
+  await _runFlutterCommand(
+    ['upgrade'],
+    workingDirectory: Directory.current,
+  );
+}
+
 Future<void> _createFlutterProject(Directory projectDirectory) async {
   final result = await _runFlutterCommand(
     ['create', '--empty', '.'],
@@ -55,6 +62,7 @@ Future<void> testWithShorebirdProject(String name,
   test(
     name,
     () async {
+      await _flutterUpgrade();
       final parentDirectory = Directory.systemTemp.createTempSync();
       final projectDirectory = Directory(
         path.join(

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -195,7 +195,7 @@ $flavors
     await extractArchiveToDisk(
         decodedBytes, path.join(this.path, 'apk-extracted'));
 
-    final raw = File(
+    final yamlString = File(
       path.join(
         this.path,
         'apk-extracted',
@@ -204,6 +204,6 @@ $flavors
         'shorebird.yaml',
       ),
     ).readAsStringSync();
-    return loadYaml(raw) as YamlMap;
+    return loadYaml(yamlString) as YamlMap;
   }
 }


### PR DESCRIPTION
When bundleling the public key in the shorebird.yaml file on android, we were not including the rest of the file, leaving the yaml incomplete.

This PR adds a fix for that.