### PR TITLE
Fix shorebird_ci

### DIFF
--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
         with:
+          # Fetch all branches and tags to ensure that Flutter can determine its version
           fetch-depth: 0
 
       - name: 🎯 Setup Dart

--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: 🎯 Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: 🎯 Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-tags: true
 
       - name: 🎯 Setup Dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
Updates the checkout action to fetch all branches and tags, which is required to determine Flutter version.

Note: regular CI still seems to be broken for an unrelated reason.

The problem we're seeing is in https://github.com/shorebirdtech/flutter/actions/runs/9196867990/job/25295975746, where our tests fail with the following:

```
Exception: Failed to create Flutter project: Downloading Linux x64 Dart SDK from Flutter engine 9f5711d6916088b4caf07badb1aef01b600eff3c...
  Building flutter tool...
  Flutter assets will be downloaded from https://download.shorebird.dev./ Make sure you trust this source!
  Note: leak_tracker_flutter_testing is pinned to version 3.0.3 by flutter_test from the flutter SDK.
  See https://dart.dev/go/sdk-version-pinning for details.
  
  The current Flutter SDK version is 0.0.0-unknown.
  
  Because every version of flutter_test from sdk depends on leak_tracker_flutter_testing >=2.0.3 which requires Flutter SDK version >=3.[18](https://github.com/shorebirdtech/flutter/actions/runs/9196867990/job/25295975746#step:5:19).0-18.0.pre.54, flutter_test from sdk is forbidden.
  So, because shorebird_test depends on flutter_test from sdk, version solving failed.
  
  
  You can try the following suggestion to make the pubspec resolve:
  * Try using the Flutter SDK version: 3.22.0. 
  
  test/shorebird_tests.dart 47:5  _createFlutterProject
  ===== asynchronous gap ===========================
  test/shorebird_tests.dart 75:9  testWithShorebirdProject.<fn>
```

I'm able to reproduce this by following the same steps as the checkout action.

Proof of fix: https://github.com/shorebirdtech/flutter/actions/runs/9197333224