### PR TITLE
set fetch depth to 0 for main ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
+        with:
           # Fetch all branches and tags to ensure that Flutter can determine its version
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
+          # Fetch all branches and tags to ensure that Flutter can determine its version
+          fetch-depth: 0
 
       - name: 🎯 Setup Dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
Same as https://github.com/shorebirdtech/flutter/pull/53, but for the main CI workflow.

Note: Ubuntu and Windows will still fail to due:

```
Run dart ./dev/bots/test.dart
▌19:43:39▐ STARTING ANALYSIS
▌19:43:39▐ SHARD=add_to_app_life_cycle_tests
╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════
║ UNEXPECTED ERROR!
║ Exception: Only iOS has add-to-add lifecycle tests at this time.
║ #0      addToAppLifeCycleRunner (file:///home/runner/work/flutter/flutter/dev/bots/suite_runners/run_add_to_app_life_cycle_tests.dart:21:5)
║ #1      main.<anonymous closure> (file:///home/runner/work/flutter/flutter/dev/bots/test.dart:233:44)
║ #2      _runFromList (file:///home/runner/work/flutter/flutter/dev/bots/test.dart:2043:32)
║ #3      selectShard (file:///home/runner/work/flutter/flutter/dev/bots/test.dart:202[8](https://github.com/shorebirdtech/flutter/actions/runs/9197435193/job/25297868422?pr=51#step:5:9):62)
║ #4      main (file:///home/runner/work/flutter/flutter/dev/bots/test.dart:232:11)
║ #5      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:2[9](https://github.com/shorebirdtech/flutter/actions/runs/9197435193/job/25297868422?pr=51#step:5:10)5:33)
║ #6      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184:12)
║ 
║ The test.dart script should be corrected to catch this error and call foundError().
║ Some tests are likely to have been skipped.
╚═══════════════════════════════════════════════════════════════════════════════
```

Mac is still failing, but it seems to be getting further