### PR TITLE
feat: adding better logging on iOS build command when generate shorebird file is not found.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -541,12 +541,13 @@ Future<XcodeBuildResult> buildXcodeProject({
 }
 
 void updateShorebirdYaml(BuildInfo buildInfo, BuildableIOSApp app) {
+  final String resolvedAppName = app.name ?? 'Runner.app';
   final File shorebirdYaml = globals.fs.file(
     globals.fs.path.join(
       app.archiveBundleOutputPath,
       'Products',
       'Applications',
-      app.name ?? 'Runner.app',
+      resolvedAppName,
       'Frameworks',
       'App.framework',
       'flutter_assets',
@@ -554,8 +555,21 @@ void updateShorebirdYaml(BuildInfo buildInfo, BuildableIOSApp app) {
     ),
   );
   if (!shorebirdYaml.existsSync()) {
+    // Find the closest existing parent of the file.
+    Directory parent = shorebirdYaml.parent;
+
+    int i = 0;
+    const int maxDepth = 6;
+    while (!parent.existsSync() && i < maxDepth) {
+      parent = parent.parent;
+      i++;
+    }
+
     throw Exception('''
 Cannot find shorebird.yaml in ${shorebirdYaml.absolute.path}.
+Resolved app name: $resolvedAppName
+Closest existing parent: ${parent.absolute.path}
+
 Please file an issue at: https://github.com/shorebirdtech/shorebird/issues/new
 ''');
   }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -559,9 +559,13 @@ void updateShorebirdYaml(BuildInfo buildInfo, BuildableIOSApp app) {
     Directory parent = shorebirdYaml.parent;
 
     int i = 0;
-    // The max depth is just a hard limit to prevent the cli from going to far behind.
+    // The max depth is just a hard limit to prevent the cli from going too far back in the
+    // folder tree and unintentionally "invading" a user folder that isn't the project. 
+    //
     // This limit should never be reached though, since at least the `Applications` or
     // `Products` folder should exist, no matter what changed in the app.
+    // This is really just an overcautious from our side to make sure we never
+    // access files that we don't need.
     const int maxDepth = 7;
     while (!parent.existsSync() && i < maxDepth) {
       parent = parent.parent;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -562,7 +562,7 @@ void updateShorebirdYaml(BuildInfo buildInfo, BuildableIOSApp app) {
     // The max depth is just a hard limit to prevent the cli from going to far behind.
     // This limit should never be reached though, since at least the `Applications` or
     // `Products` folder should exist, no matter what changed in the app.
-    const int maxDepth = 6;
+    const int maxDepth = 7;
     while (!parent.existsSync() && i < maxDepth) {
       parent = parent.parent;
       i++;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -568,10 +568,18 @@ void updateShorebirdYaml(BuildInfo buildInfo, BuildableIOSApp app) {
       i++;
     }
 
+    String parentChildren = '';
+    if (parent.existsSync()) {
+      parentChildren = parent.listSync().map((FileSystemEntity entity) => entity.basename).join(', ');
+    }
+
     throw Exception('''
 Cannot find shorebird.yaml in ${shorebirdYaml.absolute.path}.
 Resolved app name: $resolvedAppName
-Closest existing parent: ${parent.absolute.path}
+
+Closest existing parent:
+  PATH: ${parent.absolute.path}
+  CHILDREN: $parentChildren
 
 Please file an issue at: https://github.com/shorebirdtech/shorebird/issues/new
 ''');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -559,6 +559,9 @@ void updateShorebirdYaml(BuildInfo buildInfo, BuildableIOSApp app) {
     Directory parent = shorebirdYaml.parent;
 
     int i = 0;
+    // The max depth is just a hard limit to prevent the cli from going to far behind.
+    // This limit should never be reached though, since at least the `Applications` or
+    // `Products` folder should exist, no matter what changed in the app.
     const int maxDepth = 6;
     while (!parent.existsSync() && i < maxDepth) {
       parent = parent.parent;


### PR DESCRIPTION
A few issues are reporting a similar error:

`Exception: Cannot find shorebird.yaml`

 - https://github.com/shorebirdtech/shorebird/issues/2206
 - https://github.com/shorebirdtech/shorebird/issues/1914
 - https://github.com/shorebirdtech/shorebird/issues/2212
 - https://github.com/shorebirdtech/shorebird/issues/2131

That log doesn't tell us much though. This PR doesn't solve that issue, but adds better logging when this is happens so we can try troubleshoot this better.