### PR TITLE
test: add a test for shorebird.yaml compiling that uses disk

### DIFF
--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -48,6 +48,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         # TODO(eseidel): We can't run all flutter_tools tests until we make
         # our changes not throw exceptions on missing shorebird.yaml.
+        # https://github.com/shorebirdtech/shorebird/issues/2392
         run: ../../bin/flutter test test/general.shard/shorebird
         working-directory: packages/flutter_tools
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -519,7 +519,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     }
 
     try {
-      updateShorebirdYaml(buildInfo, app.shorebirdYamlPath);
+      updateShorebirdYaml(buildInfo, app.shorebirdYamlPath, environment: globals.platform.environment);
     } on Exception catch (error) {
       globals.printError('[shorebird] failed to generate shorebird configuration.\n$error');
       return XcodeBuildResult(success: false);

--- a/packages/flutter_tools/lib/src/shorebird/shorebird_yaml.dart
+++ b/packages/flutter_tools/lib/src/shorebird/shorebird_yaml.dart
@@ -9,14 +9,14 @@ import '../base/file_system.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
 
-void updateShorebirdYaml(BuildInfo buildInfo, String shorebirdYamlPath) {
+void updateShorebirdYaml(BuildInfo buildInfo, String shorebirdYamlPath, {required Map<String, String> environment}) {
   final File shorebirdYaml = globals.fs.file(shorebirdYamlPath);
   if (!shorebirdYaml.existsSync()) {
     throw Exception('shorebird.yaml not found at $shorebirdYamlPath');
   }
   final YamlDocument input = loadYamlDocument(shorebirdYaml.readAsStringSync());
   final YamlMap yamlMap = input.contents as YamlMap;
-  final Map<String, dynamic> compiled = compileShorebirdYaml(yamlMap, flavor: buildInfo.flavor, environment: globals.platform.environment);
+  final Map<String, dynamic> compiled = compileShorebirdYaml(yamlMap, flavor: buildInfo.flavor, environment: environment);
   // Currently we write out over the same yaml file, we should fix this to
   // write to a new .json file instead and avoid naming confusion between the
   // input and compiled files.


### PR DESCRIPTION
Previous tests only worked in memory, this actually tests that we change the file on disk correctly.
