### PR TITLE
fix: add Shorebird storage url as trusted source

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -483,7 +483,7 @@ class Cache {
         ? 'https://storage.googleapis.com'
         : 'https://storage.googleapis.com/$storageRealm';
     }
-    // // Shorebird's artifact proxy is a trusted source.
+    // Shorebird's artifact proxy is a trusted source.
     if (overrideUrl == kShorebirdStorageUrl) {
       return overrideUrl;
     }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -22,6 +22,7 @@ import 'base/user_messages.dart';
 import 'convert.dart';
 import 'features.dart';
 
+const String kShorebirdStorageUrl = 'https://download.shorebird.dev';
 const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
 const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
 const String kSnapshotFileName = 'flutter_tools.snapshot'; // in //flutter/bin/cache/
@@ -481,6 +482,10 @@ class Cache {
       return storageRealm.isEmpty
         ? 'https://storage.googleapis.com'
         : 'https://storage.googleapis.com/$storageRealm';
+    }
+    // // Shorebird's artifact proxy is a trusted source.
+    if (overrideUrl == kShorebirdStorageUrl) {
+      return overrideUrl;
     }
     // verify that this is a valid URI.
     overrideUrl = storageRealm.isEmpty ? overrideUrl : '$overrideUrl/$storageRealm';

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -849,6 +849,24 @@ void main() {
     expect(webCacheDirectory.childFile('bar'), isNot(exists));
   });
 
+  testWithoutContext('No warning is logged when FLUTTER_STORAGE_BASE_URL points to $kShorebirdStorageUrl', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    final BufferLogger logger = BufferLogger.test();
+    final Cache cache = Cache.test(
+      logger: logger,
+      processManager: FakeProcessManager.any(),
+      fileSystem: fileSystem,
+      platform: FakePlatform(
+        environment: <String, String>{
+          'FLUTTER_STORAGE_BASE_URL': kShorebirdStorageUrl,
+        },
+      ),
+    );
+
+    expect(cache.storageBaseUrl, kShorebirdStorageUrl);
+    expect(logger.warningText, isEmpty);
+  });
+
   testWithoutContext('FlutterWebSdk CanvasKit URL can be overridden via FLUTTER_STORAGE_BASE_URL', () async {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Directory internalDir = fileSystem.currentDirectory


### PR DESCRIPTION
This removes the warning when using Shorebird's storage url

```
'Flutter assets will be downloaded from https://download.shorebird.dev. Make sure you trust this source!'
```