### PR TITLE
Remove redundant Windows shorebird.yaml update

### DIFF
--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -135,14 +135,14 @@ Future<void> buildWindows(
     .childDirectory('flutter_assets')
     .childFile('shorebird.yaml');
 
-  if (shorebirdYamlFile.existsSync()) {
-    try {
-      updateShorebirdYaml(buildInfo.flavor, shorebirdYamlFile.path, environment: globals.platform.environment);
-    } on Exception catch (error) {
-      globals.printError('[shorebird] failed to generate shorebird configuration.\n$error');
-      throw Exception('Failed to generate shorebird configuration');
-    }
-  }
+  // if (shorebirdYamlFile.existsSync()) {
+  //   try {
+  //     updateShorebirdYaml(buildInfo.flavor, shorebirdYamlFile.path, environment: globals.platform.environment);
+  //   } on Exception catch (error) {
+  //     globals.printError('[shorebird] failed to generate shorebird configuration.\n$error');
+  //     throw Exception('Failed to generate shorebird configuration');
+  //   }
+  // }
 
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
     final String arch = getNameForTargetPlatform(targetPlatform);

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -135,15 +135,6 @@ Future<void> buildWindows(
     .childDirectory('flutter_assets')
     .childFile('shorebird.yaml');
 
-  // if (shorebirdYamlFile.existsSync()) {
-  //   try {
-  //     updateShorebirdYaml(buildInfo.flavor, shorebirdYamlFile.path, environment: globals.platform.environment);
-  //   } on Exception catch (error) {
-  //     globals.printError('[shorebird] failed to generate shorebird configuration.\n$error');
-  //     throw Exception('Failed to generate shorebird configuration');
-  //   }
-  // }
-
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
     final String arch = getNameForTargetPlatform(targetPlatform);
     final File codeSizeFile = globals.fs.directory(buildInfo.codeSizeDirectory)

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -128,12 +128,6 @@ Future<void> buildWindows(
     'Built ${globals.fs.path.relative(buildOutput.path)}',
     color: TerminalColor.green,
   );
-  final File shorebirdYamlFile = buildDirectory
-    .childDirectory('runner')
-    .childDirectory(sentenceCase(buildModeName))
-    .childDirectory('data')
-    .childDirectory('flutter_assets')
-    .childFile('shorebird.yaml');
 
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
     final String arch = getNameForTargetPlatform(targetPlatform);


### PR DESCRIPTION
Follow up to https://github.com/shorebirdtech/flutter/pull/73, removes unnecessary call to `updateShorebirdYaml`. This is now being done in packages/flutter_tools/lib/src/build_system/targets/assets.dart