### PR TITLE
fix: shorebird android tests

### DIFF
--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: 🐦 Run Flutter Tools Tests
         # TODO(eseidel): Find a nice way to run this on windows.
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
         # TODO(eseidel): We can't run all flutter_tools tests until we make
         # our changes not throw exceptions on missing shorebird.yaml.
         # https://github.com/shorebirdtech/shorebird/issues/2392
@@ -53,5 +53,8 @@ jobs:
         working-directory: packages/flutter_tools
 
       - name: 🐦 Run Shorebird Tests
+        # TODO(felangel): These tests have a dependency on pkg:flutter_flavorizr which
+        # requires XCode -- therefore they don't work on Windows.
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
         run: dart test
         working-directory: packages/shorebird_tests

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -110,15 +110,23 @@ extension ShorebirdProjectDirectoryOnDirectory on Directory {
         path.join(this.path, 'android', 'app', 'build.gradle'),
       );
 
-  Future<void> addPubDependency(String name, {bool dev = false}) {
-    return _runFlutterCommand(
+  Future<void> addPubDependency(String name, {bool dev = false}) async {
+    final result = await _runFlutterCommand(
       ['pub', 'add', if (dev) '--dev', name],
       workingDirectory: this,
     );
+    if (result.exitCode != 0) {
+      throw Exception(
+          'Failed to run `flutter pub add $name`: ${result.stderr}');
+    }
   }
 
   Future<void> addProjectFlavors() async {
-    await addPubDependency('flutter_flavorizr', dev: true);
+    await addPubDependency(
+      // TODO(felangel): revert to using published version once 3.29.0 support is released.
+      // https://github.com/AngeloAvv/flutter_flavorizr/pull/291
+      'dev:flutter_flavorizr:{"git":{"url":"https://github.com/wjlee611/flutter_flavorizr.git","ref":"chore/temp-migrate-3-29","path":"."}}',
+    );
 
     await File(
       path.join(
@@ -153,10 +161,14 @@ flavors:
       bundleId: "com.example.shorebird_test.global"
 ''');
 
-    await _runFlutterCommand(
+    final result = await _runFlutterCommand(
       ['pub', 'run', 'flutter_flavorizr'],
       workingDirectory: this,
     );
+    if (result.exitCode != 0) {
+      throw Exception(
+          'Failed to run `flutter pub run flutter_flavorizr`: ${result.stderr}');
+    }
   }
 
   void addShorebirdFlavors() {


### PR DESCRIPTION
Tests were failing because we are using pkg:flutter_flavorizr to configure flavors and the latest published version on pub.dev does not support Flutter 3.29