### PR TITLE
chore: roll dart

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'skia_revision': 'e7b8d078851fd505475fe74359e31a421e6968ea',
-  "dart_sdk_revision": "ac7987ebdca1582a18b2426e8a4f561170f5e530",
+  "dart_sdk_revision": "ef978f31c63dd16be98171e5e8da10d862b92ff8",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
   "updater_rev": "ab23721e35d2e740026def44e1469e17e3440c83",


### PR DESCRIPTION
This includes a fix to turn back on the dart snapshot version checks.  I was not able to get a local engine build working so will wait to see what the bots say, as well as will smoke test.