### PR TITLE
feat: change gen_snapshot to save dispatch table information

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'skia_revision': 'e7b8d078851fd505475fe74359e31a421e6968ea',
-  "dart_sdk_revision": "2a7a9ebe09fab3371da108a8383fdefd914631dd",
+  "dart_sdk_revision": "cde4a4dfcfb4771b322a8ca71ae3700188a09662",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
   "updater_rev": "ab23721e35d2e740026def44e1469e17e3440c83",

--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'skia_revision': 'e7b8d078851fd505475fe74359e31a421e6968ea',
-  "dart_sdk_revision": "bcca0e4e042c1c7cfe995a2e636eeb4fc01012f6",
+  "dart_sdk_revision": "2a7a9ebe09fab3371da108a8383fdefd914631dd",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
   "updater_rev": "ab23721e35d2e740026def44e1469e17e3440c83",

--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'skia_revision': 'e7b8d078851fd505475fe74359e31a421e6968ea',
-  "dart_sdk_revision": "cde4a4dfcfb4771b322a8ca71ae3700188a09662",
+  "dart_sdk_revision": "2d2db80620f5ab42e5260f61663795e1ae13cf0e",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
   "updater_rev": "ab23721e35d2e740026def44e1469e17e3440c83",

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -129,20 +129,27 @@ class AOTSnapshotter {
     final Directory outputDir = _fileSystem.directory(outputPath);
     outputDir.createSync(recursive: true);
 
-    final List<String> dumpClassTableLinkInfoArgs = <String>[
+    // Currently we only use the linker on iOS, but we will eventually split out
+    // the concept of "optimizes patch snapshot" from "uses linker" and probably
+    // only uses the linker on iOS, but optimize patch snapshots everywhere.
+    // TODO(eseidel): TargetPlatform.darwin doesn't use the linker.
+    bool usesLinker = (platform == TargetPlatform.ios || platform == TargetPlatform.darwin);
+    final List<String> dumpLinkInfoArgs = <String>[
       // Shorebird dumps the class table information during snapshot compilation which is later used during linking.
       '--print_class_table_link_debug_info_to=${_fileSystem.path.join(outputDir.parent.path, 'App.class_table.json')}',
       '--print_class_table_link_info_to=${_fileSystem.path.join(outputDir.parent.path, 'App.ct.link')}',
       '--print_field_table_link_debug_info_to=${_fileSystem.path.join(outputDir.parent.path, 'App.field_table.json')}',
       '--print_field_table_link_info_to=${_fileSystem.path.join(outputDir.parent.path, 'App.ft.link')}',
+      '--print_dispatch_table_link_debug_info_to=${_fileSystem.path.join(outputDir.parent.path, 'App.dispatch_table.json')}',
+      '--print_dispatch_table_link_info_to=${_fileSystem.path.join(outputDir.parent.path, 'App.dt.link')}',
     ];
 
     final List<String> genSnapshotArgs = <String>[
       // Shorebird uses --deterministic to improve snapshot stability and increase linking.
       '--deterministic',
-      // Only use the default Shorebird gen_snapshot args on iOS.
-      if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin)
-        ...dumpClassTableLinkInfoArgs,
+      // Only save LinkInfo if we're using the linker.
+      if (usesLinker)
+        ...dumpLinkInfoArgs,
     ];
 
     final bool targetingApplePlatform =

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -486,6 +486,8 @@ abstract final class LinkSupplement {
     // into the shorebird directory.
     maybeCopy('App.ct.link');
     maybeCopy('App.class_table.json');
+    maybeCopy('App.dt.link');
+    maybeCopy('App.dispatch_table.json');
     maybeCopy('App.ft.link');
     maybeCopy('App.field_table.json');
   }


### PR DESCRIPTION
Previously dispatch table information was dumped via analyze_snapshot
but now we're using gen_snapshot instead.  This updates flutter to pass
the right flags to gen_snapshot as well as updates to the dart version
where this change occured.