### PR TITLE
fix: include app_id in patch storage path

### DIFF
--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -42,8 +42,8 @@ if (enable_unittests) {
     testonly = true
 
     sources = [
-      "snapshots_data_handle_unittests.cc",
       "shorebird_unittests.cc",
+      "snapshots_data_handle_unittests.cc",
     ]
 
     # This only includes snapshots_data_handle and not shorebird because

--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -49,6 +49,7 @@ if (enable_unittests) {
     # This only includes snapshots_data_handle and not shorebird because
     # shorebird fails to link due to a missing updater lib.
     deps = [
+      ":shorebird",
       ":shorebird_fixtures",
       ":snapshots_data_handle",
       "//flutter/runtime",

--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -41,7 +41,10 @@ if (enable_unittests) {
   executable("shorebird_unittests") {
     testonly = true
 
-    sources = [ "snapshots_data_handle_unittests.cc" ]
+    sources = [
+      "snapshots_data_handle_unittests.cc",
+      "shorebird_unittests.cc",
+    ]
 
     # This only includes snapshots_data_handle and not shorebird because
     # shorebird fails to link due to a missing updater lib.

--- a/engine/src/flutter/shell/common/shorebird/shorebird.cc
+++ b/engine/src/flutter/shell/common/shorebird/shorebird.cc
@@ -80,6 +80,31 @@ FileCallbacks ShorebirdFileCallbacks() {
   };
 }
 
+// Given the contents of a yaml file, return the given value if it exists,
+// otherwise return an empty string.
+// Does not support nested keys.
+std::string get_value_from_yaml(const std::string& yaml,
+                                const std::string& key) {
+  std::stringstream ss(yaml);
+  std::string line;
+  std::string prefix = key + ":";
+  while (std::getline(ss, line, '\n')) {
+    if (line.find(prefix) != std::string::npos) {
+      auto ret = line.substr(line.find(prefix) + prefix.size());
+
+      // Remove leading and trailing spaces
+      while (!ret.empty() && std::isspace(ret.front())) {
+        ret.erase(0, 1);
+      }
+      while (!ret.empty() && std::isspace(ret.back())) {
+        ret.pop_back();
+      }
+      return ret;
+    }
+  }
+  return "";
+}
+
 // FIXME: consolidate this with the other ConfigureShorebird
 bool ConfigureShorebird(const ShorebirdConfigArgs& args,
                         std::string& patch_path) {
@@ -87,23 +112,10 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   auto shorebird_updater_dir_name = "shorebird_updater";
 
   // Parse app id from shorebird.yaml
-  std::string app_id = "";
-  std::stringstream ss(args.shorebird_yaml);
-  std::string line;
-  std::string appid_prefix = "appid:";
-  while (std::getline(ss, line, '\n')) {
-    if (line.find(appid_prefix) != std::string::npos) {
-      app_id = line.substr(line.find(appid_prefix) + appid_prefix.size());
-
-      // Remove leading and trailing spaces
-      while (!app_id.empty() && std::isspace(app_id.front())) {
-        app_id.erase(0, 1);
-      }
-      while (!app_id.empty() && std::isspace(app_id.back())) {
-        app_id.pop_back();
-      }
-      break;
-    }
+  std::string app_id = get_value_from_yaml(args.shorebird_yaml, "appid");
+  if (app_id.empty()) {
+    FML_LOG(ERROR) << "Shorebird updater: appid not found in shorebird.yaml";
+    return false;
   }
 
   auto code_cache_dir = fml::paths::JoinPaths(

--- a/engine/src/flutter/shell/common/shorebird/shorebird.cc
+++ b/engine/src/flutter/shell/common/shorebird/shorebird.cc
@@ -86,10 +86,30 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   patch_path = args.release_app_library_path;
   auto shorebird_updater_dir_name = "shorebird_updater";
 
+  // Parse app id from shorebird.yaml
+  std::string app_id = "";
+  std::stringstream ss(args.shorebird_yaml);
+  std::string line;
+  std::string appid_prefix = "appid:";
+  while (std::getline(ss, line, '\n')) {
+    if (line.find(appid_prefix) != std::string::npos) {
+      app_id = line.substr(line.find(appid_prefix) + appid_prefix.size());
+
+      // Remove leading and trailing spaces
+      while (!app_id.empty() && std::isspace(app_id.front())) {
+        app_id.erase(0, 1);
+      }
+      while (!app_id.empty() && std::isspace(app_id.back())) {
+        app_id.pop_back();
+      }
+      break;
+    }
+  }
+
   auto code_cache_dir = fml::paths::JoinPaths(
-      {std::move(args.code_cache_path), shorebird_updater_dir_name});
+      {std::move(args.code_cache_path), shorebird_updater_dir_name, app_id});
   auto app_storage_dir = fml::paths::JoinPaths(
-      {std::move(args.app_storage_path), shorebird_updater_dir_name});
+      {std::move(args.app_storage_path), shorebird_updater_dir_name, app_id});
 
   fml::CreateDirectory(fml::paths::GetCachesDirectory(),
                        {shorebird_updater_dir_name},

--- a/engine/src/flutter/shell/common/shorebird/shorebird.cc
+++ b/engine/src/flutter/shell/common/shorebird/shorebird.cc
@@ -83,8 +83,7 @@ FileCallbacks ShorebirdFileCallbacks() {
 // Given the contents of a yaml file, return the given value if it exists,
 // otherwise return an empty string.
 // Does not support nested keys.
-std::string get_value_from_yaml(const std::string& yaml,
-                                const std::string& key) {
+std::string GetValueFromYaml(const std::string& yaml, const std::string& key) {
   std::stringstream ss(yaml);
   std::string line;
   std::string prefix = key + ":";
@@ -112,7 +111,7 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   auto shorebird_updater_dir_name = "shorebird_updater";
 
   // Parse app id from shorebird.yaml
-  std::string app_id = get_value_from_yaml(args.shorebird_yaml, "appid");
+  std::string app_id = GetValueFromYaml(args.shorebird_yaml, "appid");
   if (app_id.empty()) {
     FML_LOG(ERROR) << "Shorebird updater: appid not found in shorebird.yaml";
     return false;

--- a/engine/src/flutter/shell/common/shorebird/shorebird.h
+++ b/engine/src/flutter/shell/common/shorebird/shorebird.h
@@ -40,8 +40,7 @@ void ConfigureShorebird(std::string code_cache_path,
                         const std::string& version,
                         const std::string& version_code);
 
-std::string get_value_from_yaml(const std::string& yaml,
-                                const std::string& key);
+std::string GetValueFromYaml(const std::string& yaml, const std::string& key);
 
 }  // namespace flutter
 

--- a/engine/src/flutter/shell/common/shorebird/shorebird.h
+++ b/engine/src/flutter/shell/common/shorebird/shorebird.h
@@ -40,6 +40,9 @@ void ConfigureShorebird(std::string code_cache_path,
                         const std::string& version,
                         const std::string& version_code);
 
+std::string get_value_from_yaml(const std::string& yaml,
+                                const std::string& key);
+
 }  // namespace flutter
 
 #endif  // FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_

--- a/engine/src/flutter/shell/common/shorebird/shorebird_unittests.cc
+++ b/engine/src/flutter/shell/common/shorebird/shorebird_unittests.cc
@@ -2,16 +2,20 @@
 
 #include "gtest/gtest.h"
 
+namespace flutter {
+namespace testing {
 TEST(Shorebird, GetValueFromYamlValueExists) {
   std::string yaml = "appid: com.example.app\nversion: 1.0.0\n";
   std::string key = "appid";
-  std::string value = get_value_from_yaml(yaml, key);
+  std::string value = GetValueFromYaml(yaml, key);
   EXPECT_EQ(value, "com.example.app");
 }
 
 TEST(Shorebird, GetValueFromYamlValueDoesNotExist) {
   std::string yaml = "appid: com.example.app\nversion: 1.0.0\n";
   std::string key = "appid2";
-  std::string value = get_value_from_yaml(yaml, key);
+  std::string value = GetValueFromYaml(yaml, key);
   EXPECT_EQ(value, "");
 }
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/common/shorebird/shorebird_unittests.cc
+++ b/engine/src/flutter/shell/common/shorebird/shorebird_unittests.cc
@@ -1,0 +1,17 @@
+#include "flutter/shell/common/shorebird/shorebird.h"
+
+#include "gtest/gtest.h"
+
+TEST(Shorebird, GetValueFromYamlValueExists) {
+  std::string yaml = "appid: com.example.app\nversion: 1.0.0\n";
+  std::string key = "appid";
+  std::string value = get_value_from_yaml(yaml, key);
+  EXPECT_EQ(value, "com.example.app");
+}
+
+TEST(Shorebird, GetValueFromYamlValueDoesNotExist) {
+  std::string yaml = "appid: com.example.app\nversion: 1.0.0\n";
+  std::string key = "appid2";
+  std::string value = get_value_from_yaml(yaml, key);
+  EXPECT_EQ(value, "");
+}

--- a/engine/src/flutter/shell/platform/linux/fl_shorebird.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_shorebird.cc
@@ -24,20 +24,8 @@ gboolean SetUpShorebird(const char* assets_path, std::string& patch_path) {
     return false;
   }
 
-  // Read appid from shorebird.yaml
-  std::string appid = "";
-  std::stringstream ss(shorebird_yaml_contents);
-  std::string line;
-  std::string appid_prefix = "appid:";
-  while (std::getline(ss, line, '\n')) {
-    if (line.find(appid_prefix) != std::string::npos) {
-      appid = line.substr(line.find(appid_prefix) + appid_prefix.size());
-      break;
-    }
-  }
-
   std::string code_cache_path =
-      fml::paths::JoinPaths({g_get_home_dir(), ".shorebird_cache", appid});
+      fml::paths::JoinPaths({g_get_home_dir(), ".shorebird_cache"});
   auto executable_location = fml::paths::GetExecutableDirectoryPath().second;
   auto app_path =
       fml::paths::JoinPaths({executable_location, "lib", "libapp.so"});


### PR DESCRIPTION
Include app_id in the patch cache path to avoid collisions. This is only necessary on desktop platforms, as mobile apps are sandboxed.

Fixes https://github.com/shorebirdtech/shorebird/issues/3174