### PR TITLE
fix: start/success reporting

### DIFF
--- a/engine/src/flutter/runtime/dart_snapshot.cc
+++ b/engine/src/flutter/runtime/dart_snapshot.cc
@@ -17,6 +17,7 @@
 #if SHOREBIRD_USE_INTERPRETER
 #include "flutter/runtime/shorebird/patch_cache.h"  // nogncheck
 #endif
+#include "flutter/shell/common/shorebird/updater.h"  // nogncheck
 
 namespace flutter {
 
@@ -151,6 +152,11 @@ static std::shared_ptr<const fml::Mapping> ResolveIsolateData(
                                                 true      // dontneed_safe
   );
 #else  // DART_SNAPSHOT_STATIC_LINK
+  // Report launch start to pair with ReportLaunchSuccess/ReportLaunchFailure
+  // in Shell::Shell. Called once per engine, matching the per-engine success/
+  // failure calls. The Rust updater no-ops when no patch is booting.
+  FML_LOG(INFO) << "Reporting launch start for patch";
+  shorebird::Updater::Instance().ReportLaunchStart();
 #if SHOREBIRD_USE_INTERPRETER
   // Try loading from a Shorebird patch first.
   if (auto mapping = TryLoadFromPatch(settings.application_library_paths,

--- a/engine/src/flutter/runtime/shorebird/patch_cache.cc
+++ b/engine/src/flutter/runtime/shorebird/patch_cache.cc
@@ -9,7 +9,6 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/runtime/shorebird/patch_mapping.h"
-#include "flutter/shell/common/shorebird/updater.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
 namespace flutter {
@@ -152,18 +151,10 @@ std::shared_ptr<const fml::Mapping> TryLoadFromPatch(
 
   FML_LOG(INFO) << "Loading symbol from patch: " << symbol_name;
 
-  // Report launch_start when we're actually about to use a patch.
-  // This is called at exactly the right time - right before the patched
-  // snapshot is loaded. We use std::once_flag to ensure it's only called
-  // once per process, and only for the first symbol (isolate data).
-  // This fixes the FlutterEngineGroup issue where report_launch_start was
-  // called too early (in ConfigureShorebird) before any patch was used.
-  static std::once_flag launch_start_flag;
+  // ReportLaunchStart is now called from ResolveIsolateData in
+  // dart_snapshot.cc, which runs before TryLoadFromPatch on all platforms.
+
   if (symbol == kIsolateDataSymbol) {
-    std::call_once(launch_start_flag, []() {
-      FML_LOG(INFO) << "Reporting launch start for patch";
-      shorebird::Updater::Instance().ReportLaunchStart();
-    });
     return PatchMapping::CreateIsolateData(cache_entry);
   } else {
     FML_CHECK(symbol == kIsolateInstructionsSymbol);

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -5109,59 +5109,57 @@ TEST_F(ShellTest, ShoulDiscardLayerTreeIfFrameIsSizedIncorrectly) {
   DestroyShell(std::move(shell), task_runners);
 }
 
-// Test that Shell creation triggers the Shorebird Updater's ReportLaunchSuccess
-// call. This is important for the crash recovery mechanism to work correctly.
-TEST_F(ShellTest, ShorebirdUpdaterReportLaunchSuccessOnShellCreation) {
-  // Install a mock updater before creating the shell
+// Test the full boot flow: ReportLaunchStart is called from
+// ResolveIsolateData, then ReportLaunchSuccess from the Shell constructor.
+// Each shell gets a paired Start+Success.
+TEST_F(ShellTest, ShorebirdBootFlowCallsLaunchStartThenSuccess) {
   auto mock = std::make_unique<shorebird::MockUpdater>();
   auto* mock_ptr = mock.get();
   shorebird::Updater::SetInstanceForTesting(std::move(mock));
-
-  EXPECT_EQ(mock_ptr->launch_success_count(), 0);
-  EXPECT_EQ(mock_ptr->launch_failure_count(), 0);
 
   auto settings = CreateSettingsForFixture();
   auto task_runners = GetTaskRunnersForFixture();
   auto shell = CreateShell(settings, task_runners);
   ASSERT_TRUE(shell);
 
-  // Shell constructor should have called ReportLaunchSuccess
-  EXPECT_EQ(mock_ptr->launch_success_count(), 1);
-  EXPECT_EQ(mock_ptr->launch_failure_count(), 0);
-
-  // Verify the call was logged
   const auto& log = mock_ptr->call_log();
-  EXPECT_TRUE(std::find(log.begin(), log.end(), "ReportLaunchSuccess") !=
-              log.end());
+  ASSERT_EQ(log.size(), 2u);
+  EXPECT_EQ(log[0], "ReportLaunchStart");
+  EXPECT_EQ(log[1], "ReportLaunchSuccess");
 
   DestroyShell(std::move(shell), task_runners);
-
-  // Clean up - reset the updater instance
   shorebird::Updater::ResetInstanceForTesting();
 }
 
-// Test that creating multiple shells only calls ReportLaunchSuccess for each
-// shell. This verifies that each Shell reports its own launch status.
+// Test that each shell gets a paired ReportLaunchStart + ReportLaunchSuccess.
 TEST_F(ShellTest, ShorebirdUpdaterReportLaunchSuccessForMultipleShells) {
   auto mock = std::make_unique<shorebird::MockUpdater>();
   auto* mock_ptr = mock.get();
   shorebird::Updater::SetInstanceForTesting(std::move(mock));
 
-  EXPECT_EQ(mock_ptr->launch_success_count(), 0);
-
   auto settings = CreateSettingsForFixture();
 
-  // Create first shell
+  // Create first shell — gets Start + Success
   auto task_runners1 = GetTaskRunnersForFixture();
   auto shell1 = CreateShell(settings, task_runners1);
   ASSERT_TRUE(shell1);
+  EXPECT_EQ(mock_ptr->launch_start_count(), 1);
   EXPECT_EQ(mock_ptr->launch_success_count(), 1);
 
-  // Create second shell
+  // Create second shell — also gets Start + Success
   auto task_runners2 = GetTaskRunnersForFixture();
   auto shell2 = CreateShell(settings, task_runners2);
   ASSERT_TRUE(shell2);
+  EXPECT_EQ(mock_ptr->launch_start_count(), 2);
   EXPECT_EQ(mock_ptr->launch_success_count(), 2);
+
+  // Full call log: Start+Success per shell
+  const auto& log = mock_ptr->call_log();
+  ASSERT_EQ(log.size(), 4u);
+  EXPECT_EQ(log[0], "ReportLaunchStart");
+  EXPECT_EQ(log[1], "ReportLaunchSuccess");
+  EXPECT_EQ(log[2], "ReportLaunchStart");
+  EXPECT_EQ(log[3], "ReportLaunchSuccess");
 
   DestroyShell(std::move(shell1), task_runners1);
   DestroyShell(std::move(shell2), task_runners2);

--- a/engine/src/flutter/shell/common/shorebird/updater_unittests.cc
+++ b/engine/src/flutter/shell/common/shorebird/updater_unittests.cc
@@ -4,8 +4,6 @@
 
 #include "flutter/shell/common/shorebird/updater.h"
 
-#include <mutex>
-
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -100,26 +98,31 @@ TEST_F(UpdaterTest, MockUpdaterResetClearsState) {
   EXPECT_FALSE(mock_->ShouldAutoUpdate());
 }
 
-// Test that demonstrates the std::once_flag pattern works correctly.
-// This is the same pattern used in TryLoadFromPatch.
-TEST_F(UpdaterTest, OncePerProcessPatternOnlyCallsOnce) {
-  static std::once_flag test_flag;
-  int call_count = 0;
+// ReportLaunchStart and ReportLaunchSuccess are always paired per shell.
+// The Rust updater no-ops both when no patch is booting.
+TEST_F(UpdaterTest, LaunchStartAndSuccessAreAlwaysPaired) {
+  Updater::Instance().ReportLaunchStart();
+  Updater::Instance().ReportLaunchSuccess();
 
-  auto simulate_patch_load = [&]() {
-    std::call_once(test_flag, [&]() {
-      call_count++;
-      Updater::Instance().ReportLaunchStart();
-    });
-  };
-
-  // Simulate multiple engines loading patches
-  simulate_patch_load();  // Engine 1
-  simulate_patch_load();  // Engine 2
-  simulate_patch_load();  // Engine 3
-
-  EXPECT_EQ(call_count, 1);
   EXPECT_EQ(mock_->launch_start_count(), 1);
+  EXPECT_EQ(mock_->launch_success_count(), 1);
+  const auto& log = mock_->call_log();
+  ASSERT_EQ(log.size(), 2u);
+  EXPECT_EQ(log[0], "ReportLaunchStart");
+  EXPECT_EQ(log[1], "ReportLaunchSuccess");
+}
+
+// ReportLaunchStart and ReportLaunchFailure are paired on failed boots.
+TEST_F(UpdaterTest, LaunchStartAndFailureAreAlwaysPaired) {
+  Updater::Instance().ReportLaunchStart();
+  Updater::Instance().ReportLaunchFailure();
+
+  EXPECT_EQ(mock_->launch_start_count(), 1);
+  EXPECT_EQ(mock_->launch_failure_count(), 1);
+  const auto& log = mock_->call_log();
+  ASSERT_EQ(log.size(), 2u);
+  EXPECT_EQ(log[0], "ReportLaunchStart");
+  EXPECT_EQ(log[1], "ReportLaunchFailure");
 }
 
 }  // namespace testing


### PR DESCRIPTION
Previously we stopped reporting start on android by accident. This fixes that.  I also removed the once-per-process guard since it's not necessary.  This should be correctly reporting once-per-shell and let the rust code only handle the first of the calls.

Fixes https://github.com/shorebirdtech/shorebird/issues/3488