### PR TITLE
feat: add verbose mode and failure logging to shorebird_tests

### DIFF
--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -138,3 +138,6 @@ jobs:
         # Quick sanity check that Android builds work on macOS too
         run: dart test test/android_test.dart --name "can build an apk"
         working-directory: packages/shorebird_tests
+        env:
+          # Enables streaming subprocess output for debugging timeouts.
+          VERBOSE: "1"

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -23,10 +23,16 @@ File get _flutterBinaryFile => File(
       ),
     );
 
+/// Whether to print line-by-line subprocess output.
+///
+/// Set the `VERBOSE` environment variable to enable streaming output,
+/// which is useful for debugging timeouts in CI.
+final bool _verbose = Platform.environment.containsKey('VERBOSE');
+
 /// Runs a flutter command using the correct binary ([_flutterBinaryFile]) with the given arguments.
 ///
-/// Streams stdout and stderr to the test output in real time so that
-/// CI logs show progress even if the process hangs or times out.
+/// Streams stdout and stderr to the test output in real time when [_verbose]
+/// is true, so CI logs show progress even if the process hangs or times out.
 Future<ProcessResult> _runFlutterCommand(
   List<String> arguments, {
   required Directory workingDirectory,
@@ -51,19 +57,22 @@ Future<ProcessResult> _runFlutterCommand(
 
   process.stdout.transform(utf8.decoder).listen((String data) {
     stdoutBuffer.write(data);
-    // Print each line with a prefix so it's easy to identify in CI logs.
-    for (final String line in data.split('\n')) {
-      if (line.isNotEmpty) {
-        print('  [$command] $line');
+    if (_verbose) {
+      for (final String line in data.split('\n')) {
+        if (line.isNotEmpty) {
+          print('  [$command] $line');
+        }
       }
     }
   });
 
   process.stderr.transform(utf8.decoder).listen((String data) {
     stderrBuffer.write(data);
-    for (final String line in data.split('\n')) {
-      if (line.isNotEmpty) {
-        print('  [$command] (stderr) $line');
+    if (_verbose) {
+      for (final String line in data.split('\n')) {
+        if (line.isNotEmpty) {
+          print('  [$command] (stderr) $line');
+        }
       }
     }
   });
@@ -72,6 +81,10 @@ Future<ProcessResult> _runFlutterCommand(
   stopwatch.stop();
   print('[$command] completed in ${stopwatch.elapsed} '
       '(exit code $exitCode)');
+  if (exitCode != 0 && !_verbose) {
+    print('[$command] stdout:\n$stdoutBuffer');
+    print('[$command] stderr:\n$stderrBuffer');
+  }
 
   return ProcessResult(
     process.pid,


### PR DESCRIPTION
## Summary
- Gate line-by-line streaming output behind `VERBOSE` env var
- Dump stdout/stderr on command failure (when not already streaming)
- Set `VERBOSE=1` in CI workflow for shorebird tests

Follow-up to #106.

## Test plan
- [ ] Verify CI logs show streaming output for each flutter command
- [ ] Verify failure output is dumped when a command fails