### PR TITLE
perf: speed up shorebird_tests with template project and Gradle cache

### DIFF
--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -38,6 +38,17 @@ jobs:
           distribution: "zulu"
           java-version: "17"
 
+      - name: 📦 Cache Gradle
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: 🐦 Run Flutter Tools Tests
         # TODO(eseidel): Find a nice way to run this on windows.
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}

--- a/packages/shorebird_tests/test/android_test.dart
+++ b/packages/shorebird_tests/test/android_test.dart
@@ -3,6 +3,8 @@ import 'package:test/test.dart';
 import 'shorebird_tests.dart';
 
 void main() {
+  setUpAll(warmUpTemplateProject);
+
   group('shorebird android projects', () {
     testWithShorebirdProject('can build an apk', (projectDirectory) async {
       await projectDirectory.runFlutterBuildApk();

--- a/packages/shorebird_tests/test/base_test.dart
+++ b/packages/shorebird_tests/test/base_test.dart
@@ -3,6 +3,8 @@ import 'package:test/test.dart';
 import 'shorebird_tests.dart';
 
 void main() {
+  setUpAll(warmUpTemplateProject);
+
   group('shorebird helpers', () {
     testWithShorebirdProject('can build a base project',
         (projectDirectory) async {

--- a/packages/shorebird_tests/test/ios_test.dart
+++ b/packages/shorebird_tests/test/ios_test.dart
@@ -3,6 +3,8 @@ import 'package:test/test.dart';
 import 'shorebird_tests.dart';
 
 void main() {
+  setUpAll(warmUpTemplateProject);
+
   group(
     'shorebird ios projects',
     () {

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -130,10 +130,20 @@ app_id: "123"
 
   // Warm up the Gradle cache with a throwaway build so subsequent
   // per-test builds are fast and don't hit the per-test timeout.
-  await _runFlutterCommand(
-    ['build', 'apk'],
-    workingDirectory: templateDir,
+  // Skip if Gradle cache is already populated (e.g., from GHA cache restore).
+  final Directory gradleCache = Directory(
+    path.join(Platform.environment['HOME'] ?? '', '.gradle', 'caches'),
   );
+  final bool hasGradleCache =
+      gradleCache.existsSync() && gradleCache.listSync().isNotEmpty;
+  if (hasGradleCache) {
+    print('[warmup] Gradle cache exists, skipping warm-up build');
+  } else {
+    await _runFlutterCommand(
+      ['build', 'apk'],
+      workingDirectory: templateDir,
+    );
+  }
 
   _templateProject = templateDir;
   return templateDir;

--- a/packages/shorebird_tests/test/shorebird_tests.dart
+++ b/packages/shorebird_tests/test/shorebird_tests.dart
@@ -91,46 +91,94 @@ Future<void> _createFlutterProject(Directory projectDirectory) async {
   }
 }
 
+/// Cached template project directory, created once and reused across tests.
+///
+/// This avoids running `flutter create` for every test, which saves
+/// significant time (especially the first Gradle/SDK download).
+Directory? _templateProject;
+
+/// Creates (or returns the cached) template Flutter project with
+/// shorebird.yaml configured. The first call runs `flutter create` and
+/// `flutter build apk` to warm up Gradle caches.
+///
+/// Call this from `setUpAll` so the expensive setup runs outside per-test
+/// timeouts.
+Future<void> warmUpTemplateProject() => _getTemplateProject();
+
+Future<Directory> _getTemplateProject() async {
+  if (_templateProject != null) {
+    return _templateProject!;
+  }
+
+  final Directory templateDir = Directory(
+    path.join(Directory.systemTemp.createTempSync().path, 'shorebird_template'),
+  )..createSync();
+
+  await _createFlutterProject(templateDir);
+
+  templateDir.pubspecFile.writeAsStringSync('''
+${templateDir.pubspecFile.readAsStringSync()}
+  assets:
+    - shorebird.yaml
+''');
+
+  File(
+    path.join(templateDir.path, 'shorebird.yaml'),
+  ).writeAsStringSync('''
+app_id: "123"
+''');
+
+  // Warm up the Gradle cache with a throwaway build so subsequent
+  // per-test builds are fast and don't hit the per-test timeout.
+  await _runFlutterCommand(
+    ['build', 'apk'],
+    workingDirectory: templateDir,
+  );
+
+  _templateProject = templateDir;
+  return templateDir;
+}
+
+/// Copies the template project to a fresh directory for test isolation.
+Future<Directory> _copyTemplateProject() async {
+  final Directory template = await _getTemplateProject();
+  final Directory testDir = Directory(
+    path.join(Directory.systemTemp.createTempSync().path, 'shorebird_test'),
+  );
+
+  // Use platform copy to preserve the full directory tree efficiently.
+  if (Platform.isWindows) {
+    await Process.run('xcopy', [
+      template.path,
+      testDir.path,
+      '/E',
+      '/I',
+      '/Q',
+    ]);
+  } else {
+    await Process.run('cp', ['-R', template.path, testDir.path]);
+  }
+
+  return testDir;
+}
+
 @isTest
 Future<void> testWithShorebirdProject(String name,
     FutureOr<void> Function(Directory projectDirectory) testFn) async {
   test(
     name,
     () async {
-      final parentDirectory = Directory.systemTemp.createTempSync();
-      final projectDirectory = Directory(
-        path.join(
-          parentDirectory.path,
-          'shorebird_test',
-        ),
-      )..createSync();
+      final Directory projectDirectory = await _copyTemplateProject();
 
       try {
-        await _createFlutterProject(projectDirectory);
-
-        projectDirectory.pubspecFile.writeAsStringSync('''
-${projectDirectory.pubspecFile.readAsStringSync()}
-  assets:
-    - shorebird.yaml
-''');
-
-        File(
-          path.join(
-            projectDirectory.path,
-            'shorebird.yaml',
-          ),
-        ).writeAsStringSync('''
-app_id: "123"
-''');
-
         await testFn(projectDirectory);
       } finally {
         projectDirectory.deleteSync(recursive: true);
       }
     },
     timeout: Timeout(
-      // These tests usually run flutter create, flutter build, etc, which can take a while,
-      // specially in CI, so setting from the default of 30 seconds to 6 minutes.
+      // Per-test timeout can be shorter now since the template project
+      // creation and Gradle warm-up happen outside the test timeout.
       Duration(minutes: 6),
     ),
   );


### PR DESCRIPTION
## Summary
- Create a template Flutter project once in `setUpAll` and copy it per test, avoiding repeated `flutter create` calls
- Run a warm-up `flutter build apk` in `setUpAll` (outside per-test timeout) to prime the Gradle cache
- Add `actions/cache` for `~/.gradle` so subsequent CI runs start warm
- Include VERBOSE env var and failure output logging from #107

This should fix the flaky 6-minute timeout failures on macOS by moving the expensive first-build overhead outside the per-test timeout.

## Test plan
- [ ] Verify CI passes on macOS (previously flaky)
- [ ] Verify individual test times are reduced
- [ ] Verify Gradle cache is populated and restored on subsequent runs