### PR TITLE
feat(ci): add missing rust steps

### DIFF
--- a/shorebird/ci/shards/linux.json
+++ b/shorebird/ci/shards/linux.json
@@ -2,6 +2,10 @@
   "android-arm64": {
     "steps": [
       {
+        "type": "rust",
+        "targets": ["aarch64-linux-android"]
+      },
+      {
         "type": "gn_ninja",
         "gn_args": ["--android", "--android-cpu=arm64", "--runtime-mode=release"],
         "ninja_targets": ["default", "gen_snapshot"],
@@ -19,6 +23,10 @@
   },
   "android-arm32": {
     "steps": [
+      {
+        "type": "rust",
+        "targets": ["armv7-linux-androideabi"]
+      },
       {
         "type": "gn_ninja",
         "gn_args": ["--android", "--runtime-mode=release"],
@@ -40,6 +48,10 @@
   },
   "android-x64": {
     "steps": [
+      {
+        "type": "rust",
+        "targets": ["x86_64-linux-android"]
+      },
       {
         "type": "gn_ninja",
         "gn_args": ["--android", "--android-cpu=x64", "--runtime-mode=release"],

--- a/shorebird/ci/shards/macos.json
+++ b/shorebird/ci/shards/macos.json
@@ -38,6 +38,10 @@
   "ios-release": {
     "steps": [
       {
+        "type": "rust",
+        "targets": ["aarch64-apple-ios"]
+      },
+      {
         "type": "gn_ninja",
         "gn_args": ["--ios", "--runtime-mode=release", "--gn-arg=shorebird_runtime=true"],
         "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
@@ -48,6 +52,10 @@
   },
   "ios-release-ext": {
     "steps": [
+      {
+        "type": "rust",
+        "targets": ["aarch64-apple-ios"]
+      },
       {
         "type": "gn_ninja",
         "gn_args": ["--ios", "--runtime-mode=release", "--darwin-extension-safe", "--xcode-symlinks", "--gn-arg=shorebird_runtime=true"],
@@ -60,6 +68,10 @@
   "ios-sim-x64": {
     "steps": [
       {
+        "type": "rust",
+        "targets": ["x86_64-apple-ios"]
+      },
+      {
         "type": "gn_ninja",
         "gn_args": ["--ios", "--runtime-mode=debug", "--simulator"],
         "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
@@ -70,6 +82,10 @@
   },
   "ios-sim-x64-ext": {
     "steps": [
+      {
+        "type": "rust",
+        "targets": ["x86_64-apple-ios"]
+      },
       {
         "type": "gn_ninja",
         "gn_args": ["--ios", "--runtime-mode=debug", "--darwin-extension-safe", "--simulator"],
@@ -82,6 +98,10 @@
   "ios-sim-arm64": {
     "steps": [
       {
+        "type": "rust",
+        "targets": ["aarch64-apple-ios-sim"]
+      },
+      {
         "type": "gn_ninja",
         "gn_args": ["--ios", "--runtime-mode=debug", "--simulator", "--simulator-cpu=arm64"],
         "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
@@ -93,6 +113,10 @@
   "ios-sim-arm64-ext": {
     "steps": [
       {
+        "type": "rust",
+        "targets": ["aarch64-apple-ios-sim"]
+      },
+      {
         "type": "gn_ninja",
         "gn_args": ["--ios", "--runtime-mode=debug", "--darwin-extension-safe", "--simulator", "--simulator-cpu=arm64"],
         "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
@@ -103,6 +127,10 @@
   },
   "mac-arm64": {
     "steps": [
+      {
+        "type": "rust",
+        "targets": ["aarch64-apple-darwin"]
+      },
       {
         "type": "gn_ninja",
         "gn_args": ["--runtime-mode=release", "--mac-cpu=arm64", "--no-prebuilt-dart-sdk"],
@@ -123,6 +151,10 @@
   },
   "mac-x64": {
     "steps": [
+      {
+        "type": "rust",
+        "targets": ["x86_64-apple-darwin"]
+      },
       {
         "type": "gn_ninja",
         "gn_args": ["--runtime-mode=release", "--mac-cpu=x64", "--no-prebuilt-dart-sdk"],


### PR DESCRIPTION
## Summary
- Adds explicit Rust build steps to every shard that produces a `libflutter` binary (Linux android-arm64/arm32/x64, macOS ios-release/ios-release-ext/ios-sim-*/mac-arm64/mac-x64)
- Each shard runs on a separate machine, so it needs its own Rust build for `libupdater.a` targeting the correct triple
- Previously only host/android shards had Rust steps; shards without them would fail or produce builds missing the updater library

## Test plan
- [ ] Verify Linux android shards build libupdater for their respective targets
- [ ] Verify macOS iOS/mac shards build libupdater for their respective targets