### PR TITLE
fix: Update iOS dSYM filename in artifact manifest

### DIFF
--- a/shorebird/ci/artifacts_manifest.template.yaml
+++ b/shorebird/ci/artifacts_manifest.template.yaml
@@ -49,7 +49,7 @@ artifact_overrides:
 
   # iOS release artifacts
   - flutter_infra_release/flutter/$engine/ios-release/artifacts.zip
-  - flutter_infra_release/flutter/$engine/ios-release/Flutter.dSYM.zip
+  - flutter_infra_release/flutter/$engine/ios-release/Flutter.framework.dSYM.zip
 
   # Linux release artifacts
   - flutter_infra_release/flutter/$engine/linux-x64/artifacts.zip

--- a/shorebird/ci/internal/generate_manifest.sh
+++ b/shorebird/ci/internal/generate_manifest.sh
@@ -76,7 +76,7 @@ artifact_overrides:
   # iOS release artifacts
   # Includes unified Flutter.framework for device and simulator (debug)
   - flutter_infra_release/flutter/\$engine/ios-release/artifacts.zip
-  - flutter_infra_release/flutter/\$engine/ios-release/Flutter.dSYM.zip
+  - flutter_infra_release/flutter/\$engine/ios-release/Flutter.framework.dSYM.zip
 
   # Linux release artifacts
   - flutter_infra_release/flutter/\$engine/linux-x64/artifacts.zip

--- a/shorebird/ci/shard_runner/test/manifest_test.dart
+++ b/shorebird/ci/shard_runner/test/manifest_test.dart
@@ -123,7 +123,7 @@ void main() {
       expect(
           manifest,
           contains(
-              r'flutter_infra_release/flutter/$engine/ios-release/Flutter.dSYM.zip'));
+              r'flutter_infra_release/flutter/$engine/ios-release/Flutter.framework.dSYM.zip'));
     });
 
     test('includes Linux release artifacts', () {


### PR DESCRIPTION
## Summary
- The manifest template referenced the old `Flutter.dSYM.zip` filename, but `mac_upload.sh` uploads `Flutter.framework.dSYM.zip` (the name as of Flutter 3.27.0)
- Updated the template, generate script, and test to match what's actually uploaded

Relates to https://github.com/shorebirdtech/shorebird/issues/3035

Related PRs:
- Console fix: https://github.com/shorebirdtech/_shorebird/pull/1791
- Artifact proxy fix: https://github.com/shorebirdtech/shorebird/pull/3623

## Test plan
- [x] Updated manifest test to expect new filename