### PR TITLE
fix: gracefully fall back to base snapshot when patch loading fails

### DIFF
--- a/engine/src/flutter/runtime/shorebird/patch_cache.cc
+++ b/engine/src/flutter/runtime/shorebird/patch_cache.cc
@@ -146,7 +146,7 @@ std::shared_ptr<const fml::Mapping> TryLoadFromPatch(
   auto cache_entry = PatchCache::Instance().GetOrLoad(patch_path);
   if (!cache_entry) {
     FML_LOG(ERROR) << "Failed to load symbol from patch at " << patch_path
-                    << ". Falling back to base snapshot.";
+                   << ". Falling back to base snapshot.";
     return nullptr;
   }
 

--- a/engine/src/flutter/runtime/shorebird/patch_cache.cc
+++ b/engine/src/flutter/runtime/shorebird/patch_cache.cc
@@ -145,7 +145,8 @@ std::shared_ptr<const fml::Mapping> TryLoadFromPatch(
   // Load the patch using the cache.
   auto cache_entry = PatchCache::Instance().GetOrLoad(patch_path);
   if (!cache_entry) {
-    FML_LOG(FATAL) << "Failed to load symbol from patch at " << patch_path;
+    FML_LOG(ERROR) << "Failed to load symbol from patch at " << patch_path
+                    << ". Falling back to base snapshot.";
     return nullptr;
   }
 


### PR DESCRIPTION
## Summary

- Changes `FML_LOG(FATAL)` to `FML_LOG(ERROR)` in `TryLoadFromPatch` when `PatchCache::GetOrLoad` returns nullptr
- This allows `ResolveIsolateData` / `ResolveIsolateInstructions` in `dart_snapshot.cc` to fall through to `SearchMapping` and load the base app snapshot instead of crashing

## Context

When a native iOS plugin (e.g., `native_geofence`) spawns a secondary headless `FlutterEngine` for background work, `TryLoadFromPatch` attempts to load the `.vmcode` patch for that engine. If loading fails for any reason (iOS background file access restrictions, `Dart_LoadELF` rejection, etc.), the `FML_LOG(FATAL)` kills the entire process via `fml::KillProcess()`.

The fallback path already exists in `dart_snapshot.cc` — both `ResolveIsolateData` and `ResolveIsolateInstructions` call `TryLoadFromPatch` first, then fall through to `SearchMapping` if it returns `nullptr`. The `FATAL` log prevented this fallback from ever executing.

With this fix, the secondary engine runs unpatched (using the base snapshot) rather than crashing the app.

Fixes https://github.com/shorebirdtech/shorebird/issues/3634

## Test plan

- [ ] Verify existing patch loading still works for the primary engine (cache hit path unchanged)
- [ ] Verify that a secondary `FlutterEngine` spawned by a native plugin falls back to base snapshot instead of crashing