### PR TITLE
Integrate Rust updater build into GN/Ninja

### DIFF
--- a/engine/src/flutter/runtime/BUILD.gn
+++ b/engine/src/flutter/runtime/BUILD.gn
@@ -114,6 +114,7 @@ source_set("runtime") {
     "//flutter/fml",
     "//flutter/lib/io",
     "//flutter/shell/common:display",
+    "//flutter/shell/common/shorebird:updater",
     "//flutter/skia",
     "//flutter/third_party/tonic",
     "//flutter/txt",

--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -1,6 +1,10 @@
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
+if (is_android) {
+  import("//build/config/android/config.gni")
+}
+
 source_set("snapshots_data_handle") {
   sources = [
     "snapshots_data_handle.cc",
@@ -13,6 +17,110 @@ source_set("snapshots_data_handle") {
     "//flutter/runtime:libdart",
     "//flutter/shell/common",
   ]
+}
+
+# Compute Rust target triple and library name for the updater build.
+_updater_dir = "//flutter/third_party/updater"
+
+if (is_android || is_ios || is_mac || is_win || is_linux) {
+  if (is_android) {
+    if (target_cpu == "arm") {
+      _rust_target_triple = "armv7-linux-androideabi"
+    } else if (target_cpu == "arm64") {
+      _rust_target_triple = "aarch64-linux-android"
+    } else if (target_cpu == "x64") {
+      _rust_target_triple = "x86_64-linux-android"
+    } else if (target_cpu == "x86") {
+      _rust_target_triple = "i686-linux-android"
+    }
+  } else if (is_ios) {
+    if (target_cpu == "arm64") {
+      _rust_target_triple = "aarch64-apple-ios"
+    } else if (target_cpu == "x64") {
+      _rust_target_triple = "x86_64-apple-ios"
+    }
+  } else if (is_mac) {
+    if (target_cpu == "arm64") {
+      _rust_target_triple = "aarch64-apple-darwin"
+    } else if (target_cpu == "x64") {
+      _rust_target_triple = "x86_64-apple-darwin"
+    }
+  } else if (is_win) {
+    if (target_cpu == "x64") {
+      _rust_target_triple = "x86_64-pc-windows-msvc"
+    }
+  } else if (is_linux) {
+    if (target_cpu == "x64") {
+      _rust_target_triple = "x86_64-unknown-linux-gnu"
+    }
+  }
+
+  if (is_win) {
+    _updater_lib_name = "updater.lib"
+  } else {
+    _updater_lib_name = "libupdater.a"
+  }
+
+  _updater_output_lib =
+      "$_updater_dir/target/$_rust_target_triple/release/$_updater_lib_name"
+
+  action("build_rust_updater") {
+    script = "//flutter/shell/common/shorebird/build_rust_updater.py"
+
+    # The stamp file is the declared output for Ninja dependency tracking.
+    _stamp = "$target_gen_dir/rust_updater_${_rust_target_triple}.stamp"
+    outputs = [ _stamp ]
+
+    args = [
+      "--rust-target",
+      _rust_target_triple,
+      "--manifest-dir",
+      rebase_path("$_updater_dir", root_build_dir),
+      "--output-lib",
+      rebase_path("$_updater_output_lib", root_build_dir),
+      "--stamp",
+      rebase_path(_stamp, root_build_dir),
+    ]
+
+    if (is_android) {
+      args += [
+        "--ndk-path",
+        rebase_path(android_ndk_root, root_build_dir),
+        "--android-api-level",
+        "$android_api_level",
+      ]
+    }
+
+    # Declare inputs so Ninja knows when to re-run the action.
+    inputs = [
+      "$_updater_dir/Cargo.toml",
+      "$_updater_dir/Cargo.lock",
+      "$_updater_dir/library/Cargo.toml",
+      "$_updater_dir/library/build.rs",
+      "$_updater_dir/library/cbindgen.toml",
+      "$_updater_dir/library/.cargo/config.toml",
+      "$_updater_dir/library/src/lib.rs",
+      "$_updater_dir/library/src/android.rs",
+      "$_updater_dir/library/src/config.rs",
+      "$_updater_dir/library/src/events.rs",
+      "$_updater_dir/library/src/file_errors.rs",
+      "$_updater_dir/library/src/logging.rs",
+      "$_updater_dir/library/src/logging_macros.rs",
+      "$_updater_dir/library/src/network.rs",
+      "$_updater_dir/library/src/test_utils.rs",
+      "$_updater_dir/library/src/time.rs",
+      "$_updater_dir/library/src/updater.rs",
+      "$_updater_dir/library/src/updater_lock.rs",
+      "$_updater_dir/library/src/yaml.rs",
+      "$_updater_dir/library/src/c_api/c_file.rs",
+      "$_updater_dir/library/src/c_api/mod.rs",
+      "$_updater_dir/library/src/cache/disk_io.rs",
+      "$_updater_dir/library/src/cache/mod.rs",
+      "$_updater_dir/library/src/cache/patch_manager.rs",
+      "$_updater_dir/library/src/cache/signing.rs",
+      "$_updater_dir/library/src/cache/updater_state.rs",
+    ]
+  }
 }
 
 # C++ wrapper around the Rust updater C API.
@@ -28,39 +136,12 @@ source_set("updater") {
   # For the Rust updater C API (shorebird_report_launch_start, etc.)
   include_dirs = [ "//flutter" ]
 
-  # Link the Rust updater static library based on target platform.
-  if (is_android) {
-    if (target_cpu == "arm") {
-      libs = [ "//flutter/third_party/updater/target/armv7-linux-androideabi/release/libupdater.a" ]
-    } else if (target_cpu == "arm64") {
-      libs = [ "//flutter/third_party/updater/target/aarch64-linux-android/release/libupdater.a" ]
-    } else if (target_cpu == "x64") {
-      libs = [ "//flutter/third_party/updater/target/x86_64-linux-android/release/libupdater.a" ]
-    } else if (target_cpu == "x86") {
-      libs = [ "//flutter/third_party/updater/target/i686-linux-android/release/libupdater.a" ]
-    }
-  } else if (is_ios) {
-    if (target_cpu == "arm64") {
-      libs = [ "//flutter/third_party/updater/target/aarch64-apple-ios/release/libupdater.a" ]
-    } else if (target_cpu == "x64") {
-      libs = [ "//flutter/third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
-    }
-  } else if (is_mac) {
-    if (target_cpu == "arm64") {
-      libs = [ "//flutter/third_party/updater/target/aarch64-apple-darwin/release/libupdater.a" ]
-    } else if (target_cpu == "x64") {
-      libs = [ "//flutter/third_party/updater/target/x86_64-apple-darwin/release/libupdater.a" ]
-    }
-  } else if (is_win) {
-    if (target_cpu == "x64") {
-      libs = [
-        "userenv.lib",
-        "//flutter/third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
-      ]
-    }
-  } else if (is_linux) {
-    if (target_cpu == "x64") {
-      libs = [ "//flutter/third_party/updater/target/x86_64-unknown-linux-gnu/release/libupdater.a" ]
+  if (is_android || is_ios || is_mac || is_win || is_linux) {
+    deps += [ ":build_rust_updater" ]
+    libs = [ _updater_output_lib ]
+
+    if (is_win) {
+      libs += [ "userenv.lib" ]
     }
   }
 }

--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -1,9 +1,6 @@
 import("//flutter/common/config.gni")
+import("//flutter/shell/common/shorebird/build_rust_updater.gni")
 import("//flutter/testing/testing.gni")
-
-if (is_android) {
-  import("//build/config/android/config.gni")
-}
 
 source_set("snapshots_data_handle") {
   sources = [
@@ -19,65 +16,22 @@ source_set("snapshots_data_handle") {
   ]
 }
 
-# Compute Rust target triple and library name for the updater build.
-_updater_dir = "//flutter/third_party/updater"
-
-if (is_android || is_ios || is_mac || is_win || is_linux) {
-  if (is_android) {
-    if (target_cpu == "arm") {
-      _rust_target_triple = "armv7-linux-androideabi"
-    } else if (target_cpu == "arm64") {
-      _rust_target_triple = "aarch64-linux-android"
-    } else if (target_cpu == "x64") {
-      _rust_target_triple = "x86_64-linux-android"
-    } else if (target_cpu == "x86") {
-      _rust_target_triple = "i686-linux-android"
-    }
-  } else if (is_ios) {
-    if (target_cpu == "arm64") {
-      _rust_target_triple = "aarch64-apple-ios"
-    } else if (target_cpu == "x64") {
-      _rust_target_triple = "x86_64-apple-ios"
-    }
-  } else if (is_mac) {
-    if (target_cpu == "arm64") {
-      _rust_target_triple = "aarch64-apple-darwin"
-    } else if (target_cpu == "x64") {
-      _rust_target_triple = "x86_64-apple-darwin"
-    }
-  } else if (is_win) {
-    if (target_cpu == "x64") {
-      _rust_target_triple = "x86_64-pc-windows-msvc"
-    }
-  } else if (is_linux) {
-    if (target_cpu == "x64") {
-      _rust_target_triple = "x86_64-unknown-linux-gnu"
-    }
-  }
-
-  if (is_win) {
-    _updater_lib_name = "updater.lib"
-  } else {
-    _updater_lib_name = "libupdater.a"
-  }
-
-  _updater_output_lib =
-      "$_updater_dir/target/$_rust_target_triple/release/$_updater_lib_name"
-
+if (shorebird_updater_supported) {
   action("build_rust_updater") {
     script = "//flutter/shell/common/shorebird/build_rust_updater.py"
 
     # The stamp file is the declared output for Ninja dependency tracking.
-    _stamp = "$target_gen_dir/rust_updater_${_rust_target_triple}.stamp"
+    _stamp =
+        "$target_gen_dir/rust_updater_${shorebird_updater_rust_target}.stamp"
     outputs = [ _stamp ]
 
     args = [
       "--rust-target",
-      _rust_target_triple,
+      shorebird_updater_rust_target,
       "--manifest-dir",
-      rebase_path("$_updater_dir", root_build_dir),
+      rebase_path("$shorebird_updater_dir", root_build_dir),
       "--output-lib",
-      rebase_path("$_updater_output_lib", root_build_dir),
+      rebase_path("$shorebird_updater_output_lib", root_build_dir),
       "--stamp",
       rebase_path(_stamp, root_build_dir),
     ]
@@ -93,33 +47,14 @@ if (is_android || is_ios || is_mac || is_win || is_linux) {
 
     # Declare inputs so Ninja knows when to re-run the action.
     inputs = [
-      "$_updater_dir/Cargo.toml",
-      "$_updater_dir/Cargo.lock",
-      "$_updater_dir/library/Cargo.toml",
-      "$_updater_dir/library/build.rs",
-      "$_updater_dir/library/cbindgen.toml",
-      "$_updater_dir/library/.cargo/config.toml",
-      "$_updater_dir/library/src/lib.rs",
-      "$_updater_dir/library/src/android.rs",
-      "$_updater_dir/library/src/config.rs",
-      "$_updater_dir/library/src/events.rs",
-      "$_updater_dir/library/src/file_errors.rs",
-      "$_updater_dir/library/src/logging.rs",
-      "$_updater_dir/library/src/logging_macros.rs",
-      "$_updater_dir/library/src/network.rs",
-      "$_updater_dir/library/src/test_utils.rs",
-      "$_updater_dir/library/src/time.rs",
-      "$_updater_dir/library/src/updater.rs",
-      "$_updater_dir/library/src/updater_lock.rs",
-      "$_updater_dir/library/src/yaml.rs",
-      "$_updater_dir/library/src/c_api/c_file.rs",
-      "$_updater_dir/library/src/c_api/mod.rs",
-      "$_updater_dir/library/src/cache/disk_io.rs",
-      "$_updater_dir/library/src/cache/mod.rs",
-      "$_updater_dir/library/src/cache/patch_manager.rs",
-      "$_updater_dir/library/src/cache/signing.rs",
-      "$_updater_dir/library/src/cache/updater_state.rs",
+      "$shorebird_updater_dir/Cargo.toml",
+      "$shorebird_updater_dir/Cargo.lock",
+      "$shorebird_updater_dir/library/Cargo.toml",
+      "$shorebird_updater_dir/library/build.rs",
+      "$shorebird_updater_dir/library/cbindgen.toml",
+      "$shorebird_updater_dir/library/.cargo/config.toml",
     ]
+    inputs += shorebird_updater_rs_sources
   }
 }
 
@@ -136,9 +71,9 @@ source_set("updater") {
   # For the Rust updater C API (shorebird_report_launch_start, etc.)
   include_dirs = [ "//flutter" ]
 
-  if (is_android || is_ios || is_mac || is_win || is_linux) {
+  if (shorebird_updater_supported) {
     deps += [ ":build_rust_updater" ]
-    libs = [ _updater_output_lib ]
+    libs = [ shorebird_updater_output_lib ]
 
     if (is_win) {
       libs += [ "userenv.lib" ]

--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.gni
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.gni
@@ -1,0 +1,71 @@
+# Copyright 2024 The Shorebird Authors. All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be
+# found in the LICENSE file.
+
+# Computes variables needed to build and link the Rust updater library.
+#
+# Exported variables:
+#   shorebird_updater_supported - Whether the current platform is supported.
+#   shorebird_updater_output_lib - Path to the built static library.
+#   shorebird_updater_rust_target - Rust target triple for the current platform.
+#   shorebird_updater_rs_sources - List of .rs source files (for GN inputs).
+
+if (is_android) {
+  import("//build/config/android/config.gni")
+}
+
+shorebird_updater_dir = "//flutter/third_party/updater"
+
+# Only build and link the Rust updater on supported platforms.
+shorebird_updater_supported =
+    is_android || is_ios || is_mac || is_win || is_linux
+
+if (shorebird_updater_supported) {
+  # Compute the Rust target triple from the GN target_os/target_cpu.
+  if (is_android) {
+    if (target_cpu == "arm") {
+      shorebird_updater_rust_target = "armv7-linux-androideabi"
+    } else if (target_cpu == "arm64") {
+      shorebird_updater_rust_target = "aarch64-linux-android"
+    } else if (target_cpu == "x64") {
+      shorebird_updater_rust_target = "x86_64-linux-android"
+    } else if (target_cpu == "x86") {
+      shorebird_updater_rust_target = "i686-linux-android"
+    }
+  } else if (is_ios) {
+    if (target_cpu == "arm64") {
+      shorebird_updater_rust_target = "aarch64-apple-ios"
+    } else if (target_cpu == "x64") {
+      shorebird_updater_rust_target = "x86_64-apple-ios"
+    }
+  } else if (is_mac) {
+    if (target_cpu == "arm64") {
+      shorebird_updater_rust_target = "aarch64-apple-darwin"
+    } else if (target_cpu == "x64") {
+      shorebird_updater_rust_target = "x86_64-apple-darwin"
+    }
+  } else if (is_win) {
+    if (target_cpu == "x64") {
+      shorebird_updater_rust_target = "x86_64-pc-windows-msvc"
+    }
+  } else if (is_linux) {
+    if (target_cpu == "x64") {
+      shorebird_updater_rust_target = "x86_64-unknown-linux-gnu"
+    }
+  }
+
+  if (is_win) {
+    _updater_lib_name = "updater.lib"
+  } else {
+    _updater_lib_name = "libupdater.a"
+  }
+
+  shorebird_updater_output_lib = "$shorebird_updater_dir/target/$shorebird_updater_rust_target/release/$_updater_lib_name"
+
+  # Glob all .rs source files so the input list stays in sync automatically.
+  shorebird_updater_rs_sources =
+      exec_script("//flutter/shell/common/shorebird/list_rust_files.py",
+                  [ rebase_path("$shorebird_updater_dir/library/src",
+                                root_build_dir) ],
+                  "list lines")
+}

--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2024 The Shorebird Authors. All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be
+# found in the LICENSE file.
+
+"""Build the Rust updater library via cargo, invoked as a GN action."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Build the Rust updater static library.')
+  parser.add_argument(
+      '--rust-target', required=True, help='Rust target triple (e.g. aarch64-linux-android)'
+  )
+  parser.add_argument(
+      '--manifest-dir', required=True, help='Directory containing the workspace Cargo.toml'
+  )
+  parser.add_argument('--output-lib', required=True, help='Expected output library path')
+  parser.add_argument('--stamp', required=True, help='Stamp file to write on success')
+  parser.add_argument('--ndk-path', help='Path to the Android NDK (required for Android targets)')
+  parser.add_argument(
+      '--android-api-level', type=int, help='Android API level (required for Android targets)'
+  )
+  args = parser.parse_args()
+
+  env = os.environ.copy()
+
+  is_android = 'android' in args.rust_target
+
+  if is_android:
+    if not args.ndk_path or not args.android_api_level:
+      print(
+          'ERROR: --ndk-path and --android-api-level are required for '
+          'Android targets.',
+          file=sys.stderr
+      )
+      return 1
+    _configure_android_env(env, args.rust_target, args.ndk_path, args.android_api_level)
+
+  manifest_path = os.path.join(args.manifest_dir, 'Cargo.toml')
+
+  cmd = [
+      'cargo',
+      'build',
+      '--release',
+      '--target',
+      args.rust_target,
+      '--manifest-path',
+      manifest_path,
+      '-p',
+      'updater',
+  ]
+
+  print(f'Running: {" ".join(cmd)}', flush=True)
+  result = subprocess.run(cmd, env=env)
+  if result.returncode != 0:
+    print(f'ERROR: cargo build failed with exit code {result.returncode}', file=sys.stderr)
+    return result.returncode
+
+  if not os.path.exists(args.output_lib):
+    print(f'ERROR: Expected output library not found: {args.output_lib}', file=sys.stderr)
+    return 1
+
+  # Write stamp file to signal success to Ninja.
+  with open(args.stamp, 'w') as f:
+    f.write('')
+
+  return 0
+
+
+def _configure_android_env(env, rust_target, ndk_path, api_level):
+  """Set environment variables so cargo can cross-compile for Android."""
+  # Determine the host platform tag for NDK toolchain paths.
+  if sys.platform.startswith('linux'):
+    host_tag = 'linux-x86_64'
+  elif sys.platform == 'darwin':
+    host_tag = 'darwin-x86_64'
+  elif sys.platform == 'win32':
+    host_tag = 'windows-x86_64'
+  else:
+    raise RuntimeError(f'Unsupported host platform: {sys.platform}')
+
+  toolchain_bin = os.path.join(ndk_path, 'toolchains', 'llvm', 'prebuilt', host_tag, 'bin')
+
+  # The NDK clang binary uses a slightly different prefix for armv7.
+  # Rust target: armv7-linux-androideabi
+  # NDK prefix:  armv7a-linux-androideabi
+  clang_prefix = rust_target
+  if rust_target.startswith('armv7-'):
+    clang_prefix = 'armv7a-' + rust_target[len('armv7-'):]
+
+  clang = os.path.join(toolchain_bin, f'{clang_prefix}{api_level}-clang')
+  ar = os.path.join(toolchain_bin, 'llvm-ar')
+
+  # Cargo looks for CARGO_TARGET_<TRIPLE>_LINKER where the triple is
+  # upper-cased with hyphens replaced by underscores.
+  triple_env = rust_target.upper().replace('-', '_')
+  env[f'CARGO_TARGET_{triple_env}_LINKER'] = clang
+  env['CC'] = clang
+  env['AR'] = ar
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
@@ -41,7 +41,11 @@ def main():
       return 1
     _configure_android_env(env, args.rust_target, args.ndk_path, args.android_api_level)
 
-  manifest_path = os.path.join(args.manifest_dir, 'Cargo.toml')
+  # GN passes paths relative to the build output dir (which is cwd when
+  # Ninja runs the action). Resolve them to absolute paths so they work
+  # regardless of cargo's working directory.
+  manifest_path = os.path.abspath(os.path.join(args.manifest_dir, 'Cargo.toml'))
+  output_lib = os.path.abspath(args.output_lib)
 
   cmd = [
       'cargo',
@@ -61,8 +65,8 @@ def main():
     print(f'ERROR: cargo build failed with exit code {result.returncode}', file=sys.stderr)
     return result.returncode
 
-  if not os.path.exists(args.output_lib):
-    print(f'ERROR: Expected output library not found: {args.output_lib}', file=sys.stderr)
+  if not os.path.exists(output_lib):
+    print(f'ERROR: Expected output library not found: {output_lib}', file=sys.stderr)
     return 1
 
   # Write stamp file to signal success to Ninja.
@@ -74,6 +78,10 @@ def main():
 
 def _configure_android_env(env, rust_target, ndk_path, api_level):
   """Set environment variables so cargo can cross-compile for Android."""
+  # GN passes paths relative to the build output dir. Resolve to absolute
+  # so that cargo and the cc crate can find the NDK tools.
+  ndk_path = os.path.abspath(ndk_path)
+
   # Determine the host platform tag for NDK toolchain paths.
   if sys.platform.startswith('linux'):
     host_tag = 'linux-x86_64'

--- a/engine/src/flutter/shell/common/shorebird/list_rust_files.py
+++ b/engine/src/flutter/shell/common/shorebird/list_rust_files.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright 2024 The Shorebird Authors. All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be
+# found in the LICENSE file.
+
+"""List Rust source files for GN input tracking.
+
+Walks a directory tree and prints all .rs files as absolute paths. Used by
+GN's exec_script to generate an input list for the Rust updater build action.
+
+Usage:
+  python3 list_rust_files.py <directory>
+"""
+
+import os
+import sys
+
+
+def main():
+  directory = os.path.abspath(sys.argv[1])
+  for root, _, files in os.walk(directory):
+    for filename in sorted(files):
+      if filename.endswith('.rs'):
+        print(os.path.join(root, filename).replace(os.sep, '/'))
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
## Summary
- Add a GN `action()` that invokes `cargo build` for the Rust updater library, so Ninja (and ET) can build the complete Shorebird engine without a separate shell script prerequisite step
- Add `build_rust_updater.py` Python wrapper that handles cargo invocation and Android NDK cross-compilation setup
- Simplify `source_set("updater")` in BUILD.gn to depend on the new action instead of hardcoding pre-built library paths
- Fix missing `//flutter/shell/common/shorebird:updater` dependency in `runtime/BUILD.gn` (pre-existing bug)

## Test plan
- [x] `et build -c host_debug` (macOS host build)
- [x] `et build -c ios_release` (iOS cross-compile)
- [x] `et build -c android_release_arm64` (Android cross-compile)
- [ ] Linux CI
- [ ] Windows CI