### PR TITLE
chore: roll updater to adacb419

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@ vars = {
   "dart_sdk_revision": "667fc4ab87165889877a529f72c17bdb3b36738d",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "dc2cd0a86a89e53cd5c0f87efe4ccea93fae9eae",
+  "updater_rev": "adacb4190cb4af2e2920c18d8a904f4c6b138ee4",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.


### PR DESCRIPTION
Rolls `shorebirdtech/updater` `dc2cd0a..adacb41` (15 commits).

## Notable changes
- refactor: replace reqwest with ureq to reduce binary size (shorebirdtech/updater#317)
- feat: add resumable downloads with streaming to disk (shorebirdtech/updater#313)
- fix: improve inflate error handling and validate compressed patches (shorebirdtech/updater#314)
- fix: checkForUpdate reports restartRequired when current patch is rolled back (shorebirdtech/updater#312)
- fix: resolve all Dependabot security vulnerabilities (shorebirdtech/updater#316)
- perf: add release profile to reduce binary size (shorebirdtech/updater#328)
- plus clippy/fmt CI, doc, and test additions

Diff: https://github.com/shorebirdtech/updater/compare/dc2cd0a86a89e53cd5c0f87efe4ccea93fae9eae...adacb4190cb4af2e2920c18d8a904f4c6b138ee4

Note: `dart_sdk_revision` is already at the tip of `shorebird/dev`, so no Dart roll needed. Engine build will be kicked off from `shorebird/dev` after this lands.