### PR TITLE
fix: thread Apple deployment target into Rust updater build

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@ vars = {
   "dart_sdk_revision": "667fc4ab87165889877a529f72c17bdb3b36738d",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "dc2cd0a86a89e53cd5c0f87efe4ccea93fae9eae",
+  "updater_rev": "adacb4190cb4af2e2920c18d8a904f4c6b138ee4",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -2,6 +2,10 @@ import("//flutter/common/config.gni")
 import("//flutter/shell/common/shorebird/build_rust_updater.gni")
 import("//flutter/testing/testing.gni")
 
+if (is_ios || is_mac) {
+  import("//build/config/darwin/darwin_sdk.gni")
+}
+
 source_set("snapshots_data_handle") {
   sources = [
     "snapshots_data_handle.cc",
@@ -42,6 +46,27 @@ if (shorebird_updater_supported) {
         rebase_path(android_ndk_root, root_build_dir),
         "--android-api-level",
         "$android_api_level",
+      ]
+    }
+
+    if (is_ios) {
+      # Thread the engine's iOS deployment target into the cargo build so
+      # the cc crate (compiling C deps like zstd-sys) and rustc's cdylib
+      # link step both target the same iOS version as the C++ engine.
+      # Without this, cargo defaults to whatever rustc/cc bake in (rustc's
+      # built-in target spec for aarch64-apple-ios is iOS 10/11, while cc
+      # picks up the host SDK), which causes link warnings and unresolved
+      # symbols like ___chkstk_darwin.
+      args += [
+        "--ios-deployment-target",
+        ios_deployment_target,
+      ]
+    }
+
+    if (is_mac) {
+      args += [
+        "--mac-deployment-target",
+        mac_deployment_target,
       ]
     }
 

--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
@@ -25,11 +25,21 @@ def main():
   parser.add_argument(
       '--android-api-level', type=int, help='Android API level (required for Android targets)'
   )
+  parser.add_argument(
+      '--ios-deployment-target',
+      help='iOS deployment target (e.g. 13.0); required for *-apple-ios targets',
+  )
+  parser.add_argument(
+      '--mac-deployment-target',
+      help='macOS deployment target (e.g. 10.15); required for *-apple-darwin targets',
+  )
   args = parser.parse_args()
 
   env = os.environ.copy()
 
   is_android = 'android' in args.rust_target
+  is_apple_ios = 'apple-ios' in args.rust_target
+  is_apple_darwin = 'apple-darwin' in args.rust_target
 
   if is_android:
     if not args.ndk_path or not args.android_api_level:
@@ -40,6 +50,28 @@ def main():
       )
       return 1
     _configure_android_env(env, args.rust_target, args.ndk_path, args.android_api_level)
+
+  if is_apple_ios:
+    if not args.ios_deployment_target:
+      print(
+          'ERROR: --ios-deployment-target is required for *-apple-ios targets.',
+          file=sys.stderr,
+      )
+      return 1
+    # Setting IPHONEOS_DEPLOYMENT_TARGET makes both the cc crate (compiling
+    # transitive C deps like zstd-sys) and rustc's cdylib link step honor
+    # the engine's iOS deployment target instead of falling back to their
+    # respective defaults (host SDK for cc, target-spec default for rustc).
+    env['IPHONEOS_DEPLOYMENT_TARGET'] = args.ios_deployment_target
+
+  if is_apple_darwin:
+    if not args.mac_deployment_target:
+      print(
+          'ERROR: --mac-deployment-target is required for *-apple-darwin targets.',
+          file=sys.stderr,
+      )
+      return 1
+    env['MACOSX_DEPLOYMENT_TARGET'] = args.mac_deployment_target
 
   # GN passes paths relative to the build output dir (which is cwd when
   # Ninja runs the action). Resolve them to absolute paths so they work


### PR DESCRIPTION
## Summary
`build_rust_updater.py` (added in #120) sets up cross-compile env for Android targets but had nothing for `*-apple-ios` / `*-apple-darwin`. Cargo for `aarch64-apple-ios` was running with no `IPHONEOS_DEPLOYMENT_TARGET` at all, which broke two ways at once after the recent updater roll pulled in `zstd-sys` (transitively, via ureq's compression features):

1. The `cc` crate (compiling zstd's C sources) had no deployment target to honor and picked up the host Xcode SDK — that's the "built for newer 'iOS' version (18.0)" half of every link warning.
2. rustc's cdylib link step for `aarch64-apple-ios` used Rust's built-in target-spec deployment target, which is iOS 10/11. That's the "being linked (10.0)" half — and it's why `___chkstk_darwin` ended up unresolved (compiler-rt only auto-links that symbol for new-enough deployment targets).

The engine's GN side was correct all along: `darwin_sdk.gni:52` says `ios_deployment_target = "13.0"`, matching Flutter stable. Only the cargo invocation was off.

## Fix
Pass `--ios-deployment-target` / `--mac-deployment-target` from `BUILD.gn`, sourced from `darwin_sdk.gni`'s `ios_deployment_target` / `mac_deployment_target`. The python script sets `IPHONEOS_DEPLOYMENT_TARGET` / `MACOSX_DEPLOYMENT_TARGET` env vars before invoking cargo, so both the cc crate and rustc honor the same target as the C++ build. Sourcing from GN means the Rust build can never drift from the engine's deployment target — they share one source of truth.

This is a follow-up to #120; tagging @bdero for review since this extends that work directly.

## Test plan
- [ ] Engine build green for `iOS arm64` (was failing — see shorebirdtech/_shorebird#2014 for the original log)
- [ ] Engine build still green for Android, Linux, Windows, macOS

The build will be triggered against `shorebird/dev` tip once this lands; testing standalone is awkward because `build_engine.yaml` only takes a single `engine_revision` SHA.

Tracking: shorebirdtech/_shorebird#2014
Follow-up to: #120