### PR TITLE
fix: put cargo target dir inside the GN build output dir

### DIFF
--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -34,6 +34,8 @@ if (shorebird_updater_supported) {
       shorebird_updater_rust_target,
       "--manifest-dir",
       rebase_path("$shorebird_updater_dir", root_build_dir),
+      "--target-dir",
+      rebase_path("$shorebird_updater_target_dir", root_build_dir),
       "--output-lib",
       rebase_path("$shorebird_updater_output_lib", root_build_dir),
       "--stamp",

--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.gni
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.gni
@@ -60,7 +60,16 @@ if (shorebird_updater_supported) {
     _updater_lib_name = "libupdater.a"
   }
 
-  shorebird_updater_output_lib = "$shorebird_updater_dir/target/$shorebird_updater_rust_target/release/$_updater_lib_name"
+  # Cargo target dir lives inside the GN build output dir, not inside the
+  # source tree. This means:
+  #   - `rm -rf out/<config>` clobbers compiled rust artifacts the same
+  #     way it clobbers compiled C++ artifacts; no special-case cleanup
+  #     in checkout.sh.
+  #   - Each GN config (debug/release/ios/android/etc.) gets its own
+  #     cargo target dir, so they don't step on each other's rlibs.
+  #   - The source checkout stays clean, which is what GN/ninja expects.
+  shorebird_updater_target_dir = "$root_out_dir/cargo_target"
+  shorebird_updater_output_lib = "$shorebird_updater_target_dir/$shorebird_updater_rust_target/release/$_updater_lib_name"
 
   # Glob all .rs source files so the input list stays in sync automatically.
   shorebird_updater_rs_sources =

--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
@@ -19,6 +19,11 @@ def main():
   parser.add_argument(
       '--manifest-dir', required=True, help='Directory containing the workspace Cargo.toml'
   )
+  parser.add_argument(
+      '--target-dir',
+      required=True,
+      help='Cargo target directory; should live inside the GN build output dir',
+  )
   parser.add_argument('--output-lib', required=True, help='Expected output library path')
   parser.add_argument('--stamp', required=True, help='Stamp file to write on success')
   parser.add_argument('--ndk-path', help='Path to the Android NDK (required for Android targets)')
@@ -77,6 +82,7 @@ def main():
   # Ninja runs the action). Resolve them to absolute paths so they work
   # regardless of cargo's working directory.
   manifest_path = os.path.abspath(os.path.join(args.manifest_dir, 'Cargo.toml'))
+  target_dir = os.path.abspath(args.target_dir)
   output_lib = os.path.abspath(args.output_lib)
 
   cmd = [
@@ -87,6 +93,8 @@ def main():
       args.rust_target,
       '--manifest-path',
       manifest_path,
+      '--target-dir',
+      target_dir,
       '-p',
       'updater',
   ]


### PR DESCRIPTION
## Summary
`build_rust_updater` previously let cargo write its `target/` directly into the source tree at `flutter/engine/src/flutter/third_party/updater/target/`. Two consequences:

1. **The engine's existing `rm -rf out/<config>` clobber on every build doesn't touch it**, so compiled rust artifacts silently survived across runs. This just bit us: a stale `libzstd_sys.rlib` reused on Sandpiper masked the `IPHONEOS_DEPLOYMENT_TARGET` fix from #123 entirely — the new env var never had a chance to take effect because cargo short-circuited the rebuild.
2. **All GN configs (debug/release/ios/android/...) shared one cargo target dir**, stepping on each other's rlibs.

## Fix
- Pass `--target-dir` to cargo, pointing at `$root_out_dir/cargo_target`.
- Update `build_rust_updater.gni`'s `shorebird_updater_output_lib` to match.

The cargo workspace now lives next to the rest of the GN build output and is clobbered by the same `rm -rf out` that has always clobbered the C++ engine artifacts. No special-case cleanup in `checkout.sh`. Each GN config gets its own cargo target dir.

## Note for reviewer
This is a follow-up to #123 (which threaded `IPHONEOS_DEPLOYMENT_TARGET` through to cargo) and a follow-up to #120 (your original GN/Ninja integration). Together with #123, this should make the iOS arm64 zstd link error from shorebirdtech/_shorebird#2014 actually go away on the next Sandpiper build.

## Note for ops
The old `target/` directory at `~/.engine_checkout/flutter/engine/src/flutter/third_party/updater/target/` on the Sandpiper host will become orphaned after this lands (the new code never writes there). It's harmless to leave around but somebody should `rm -rf` it the next time they ssh in.

## Bigger picture (not in this PR)
We discussed whether to keep cargo-as-opaque-blob or migrate to rustc-direct (Fuchsia/Chromium style, where each crate becomes a GN target compiled by `rustc` directly with the engine's clang for any `*-sys` C code). For now we're keeping cargo since this is a one-week-old integration with one Rust dep, but the rustc-direct option becomes worth doing once we have a second crate or hit hermetic-build requirements. There's a `// TODO` worth adding in `build_rust_updater.gni` later.

Tracking: shorebirdtech/_shorebird#2014
Follow-up to: #120, #123