### PR TITLE
fix: force static CRT for cc-compiled C deps on Windows

### DIFF
--- a/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
+++ b/engine/src/flutter/shell/common/shorebird/build_rust_updater.py
@@ -45,6 +45,7 @@ def main():
   is_android = 'android' in args.rust_target
   is_apple_ios = 'apple-ios' in args.rust_target
   is_apple_darwin = 'apple-darwin' in args.rust_target
+  is_msvc = 'pc-windows-msvc' in args.rust_target
 
   if is_android:
     if not args.ndk_path or not args.android_api_level:
@@ -77,6 +78,9 @@ def main():
       )
       return 1
     env['MACOSX_DEPLOYMENT_TARGET'] = args.mac_deployment_target
+
+  if is_msvc:
+    _configure_msvc_env(env, args.rust_target)
 
   # GN passes paths relative to the build output dir (which is cwd when
   # Ninja runs the action). Resolve them to absolute paths so they work
@@ -114,6 +118,29 @@ def main():
     f.write('')
 
   return 0
+
+
+def _configure_msvc_env(env, rust_target):
+  """Force the cc crate to compile transitive C deps with the static CRT.
+
+  The engine's Windows build uses the static CRT (/MT). The updater's
+  .cargo/config.toml sets `-C target-feature=+crt-static` so the rlib is
+  compiled to expect static-CRT linkage. However, cargo populates
+  CARGO_CFG_TARGET_FEATURE from the rustc target spec's default features,
+  not from user rustflags, so +crt-static is invisible to build scripts.
+  The cc crate (used by transitive *-sys deps like zstd-sys to compile
+  their C sources) therefore falls back to /MD, producing .obj files
+  full of __imp_* references that the engine's /MT link cannot resolve
+  (e.g. __imp_clock, __imp__wassert, __imp_qsort_s).
+
+  Force /MT via the per-target CFLAGS env that the cc crate honors. cc
+  appends these flags at the end of its command line, so cl.exe sees
+  `/MD ... /MT` and emits warning D9025 ("overriding '/MD' with '/MT'")
+  and uses the last one -- /MT wins.
+  """
+  triple_env = rust_target.replace('-', '_')
+  env[f'CFLAGS_{triple_env}'] = '/MT'
+  env[f'CXXFLAGS_{triple_env}'] = '/MT'
 
 
 def _configure_android_env(env, rust_target, ndk_path, api_level):


### PR DESCRIPTION
## Summary
The engine's Windows build uses the static CRT (`/MT`). The updater's `.cargo/config.toml` already sets `-C target-feature=+crt-static`, so rustc compiles the updater rlib expecting static-CRT linkage. But cargo populates `CARGO_CFG_TARGET_FEATURE` from the **rustc target spec's default features**, not from user rustflags, so `+crt-static` is invisible to build scripts. The cc crate — used by transitive `*-sys` deps like zstd-sys to compile their C sources — therefore falls back to `/MD`, producing `.obj` files full of `__imp_*` references that the engine's `/MT` link cannot resolve.

This started mattering after the updater rolled to a ureq-based transport stack whose compression features pull in `zstd-sys`. Before that roll, the updater had no significant transitive C deps and nobody noticed the inconsistency.

Symptom from the failing build:
```
updater.lib(...zdict.o)      : error LNK2019: unresolved external symbol __imp_clock
updater.lib(...fastcover.o)  : error LNK2001: unresolved external symbol __imp_clock
updater.lib(...cover.o)      : error LNK2019: unresolved external symbol __imp_qsort_s
updater.lib(...divsufsort.o) : error LNK2019: unresolved external symbol __imp__wassert
flutter_windows.dll : fatal error LNK1120: 3 unresolved externals
```

## Fix
Set `CFLAGS_x86_64_pc_windows_msvc=/MT` (and `CXXFLAGS_`) in the environment before invoking cargo. The cc crate appends per-target `CFLAGS` to its computed flags, so cl.exe sees `/MD ... /MT`, emits warning D9025 "overriding '/MD' with '/MT'", and uses the last one specified. `/MT` wins, `.obj` files reference the static CRT, and the engine link succeeds.

## Tradeoffs / followups
- Another instance of the toolchain-consistency problem #123 solved for iOS deployment target. Each new platform-specific C build setting we discover needs another env var threaded through `build_rust_updater.py`. Longer term this argues for rustc-direct à la Fuchsia/Chromium so the engine's clang is the only C compiler in the picture.
- Relies on cl.exe treating D9025 as a warning, not an error. Defensive alternative is `CRATE_CC_NO_DEFAULTS=1` + providing the full flags list, which is a much bigger commitment.
- If we end up dropping zstd from ureq features in the updater (separate conversation), this env var isn't strictly required for *this* roll — but it stays in as defense-in-depth for future C-containing `*-sys` deps.

Tracking: shorebirdtech/_shorebird#2014
Follow-up to: #123, #124