### PR TITLE
fix: remove legacy pre-GN cargo preamble from CI build scripts

### DIFF
--- a/shorebird/ci/internal/linux_build.sh
+++ b/shorebird/ci/internal/linux_build.sh
@@ -17,26 +17,16 @@ ENGINE_OUT=$ENGINE_SRC/out
 UPDATER_SRC=$ENGINE_SRC/flutter/third_party/updater
 HOST_ARCH='linux-x64'
 
-# Build the Rust library.
-cd $UPDATER_SRC/library
-
-# 24 is Flutter's current minimum supported version,
-# see https://docs.flutter.dev/reference/supported-platforms
-# previous iterations of cargo-ndk required the version to be passed as
-# -p <version>, but that no longer seems needed.
-# We always use the hermetic NDK from the engine repo.
-# The "unmodified" CIPD package keeps the NDK at the standard Android SDK path.
-ANDROID_NDK_HOME=$(echo "$ENGINE_SRC/flutter/third_party/android_tools/sdk/ndk"/*) \
-cargo ndk \
-    --target armv7-linux-androideabi \
-    --target aarch64-linux-android \
-    --target i686-linux-android \
-    --target x86_64-linux-android \
-    build --release
-
-cargo build --release --target x86_64-unknown-linux-gnu
-
-# Build the patch tool.
+# The Rust updater library is now built as part of the GN/Ninja engine
+# build — see //flutter/shell/common/shorebird/BUILD.gn's
+# build_rust_updater action. Android cross-compile env (NDK paths,
+# CC/AR/LINKER) is configured by build_rust_updater.py. Any engine target
+# that depends (transitively) on //flutter/shell/common/shorebird:updater
+# pulls in libupdater.a automatically.
+#
+# Build the patch tool. This is a standalone CLI, not linked into the
+# engine, so the GN build doesn't cover it.
+# TODO(shorebird): move the patch tool into the GN build too.
 cd $UPDATER_SRC/patch
 cargo build --release
 

--- a/shorebird/ci/internal/mac_build.sh
+++ b/shorebird/ci/internal/mac_build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -e
 
-# FIXME: This script should be deleted and instead these steps be part
-# of the GN build process.
-# I haven't investigated how to build rust from GN with the Android NDK yet.
-
 # Usage:
 # ./mac_build.sh engine_path
 
@@ -21,19 +17,15 @@ ENGINE_OUT=$ENGINE_SRC/out
 UPDATER_SRC=$ENGINE_SRC/flutter/third_party/updater
 HOST_ARCH='darwin-x64'
 
-# Build the Rust library.
-cd $UPDATER_SRC/library
-
-# Build iOS and MacOS
-cargo build \
-  --target aarch64-apple-ios \
-  --target x86_64-apple-ios \
-  --target aarch64-apple-darwin \
-  --target x86_64-apple-darwin \
-  --release
-
-# Build the patch tool.
-# Again, this belongs as part of the gn build.
+# The Rust updater library is now built as part of the GN/Ninja engine
+# build — see //flutter/shell/common/shorebird/BUILD.gn's
+# build_rust_updater action. Any engine target that depends (transitively)
+# on //flutter/shell/common/shorebird:updater will pull in libupdater.a
+# automatically.
+#
+# Build the patch tool. This is a standalone CLI, not linked into the
+# engine, so the GN build doesn't cover it.
+# TODO(shorebird): move the patch tool into the GN build too.
 cd $UPDATER_SRC/patch
 cargo build --release
 

--- a/shorebird/ci/internal/win_build.sh
+++ b/shorebird/ci/internal/win_build.sh
@@ -10,11 +10,11 @@ ENGINE_OUT=$ENGINE_SRC/out
 UPDATER_SRC=$ENGINE_SRC/flutter/third_party/updater
 HOST_ARCH='windows-x64'
 
-# Build the Rust library.
-cd $UPDATER_SRC/library
-
-cargo build --release \
-  --target x86_64-pc-windows-msvc
+# The Rust updater library is now built as part of the GN/Ninja engine
+# build — see //flutter/shell/common/shorebird/BUILD.gn's
+# build_rust_updater action. Any engine target that depends (transitively)
+# on //flutter/shell/common/shorebird:updater pulls in updater.lib
+# automatically.
 
 # Compile the engine using the steps here:
 # https://github.com/flutter/flutter/wiki/Compiling-the-engine#compiling-for-android-from-macos-or-linux


### PR DESCRIPTION
## Summary
`mac_build.sh`, `linux_build.sh`, and `win_build.sh` each had a leftover `cd $UPDATER_SRC/library && cargo build --target ...` preamble from before #120's GN/Ninja integration of the rust updater build. `mac_build.sh` even had a `FIXME` at the top documenting the intent to delete it. These preambles:

1. **Bypass the GN action entirely**, so none of the env-var plumbing in `build_rust_updater.py` applies — no `IPHONEOS_DEPLOYMENT_TARGET` from #123, no `CFLAGS_*_windows_msvc=/MT` from #125, no Android NDK env from #120's own `_configure_android_env`.
2. **Write to the source-tree default cargo target dir** at `third_party/updater/target/`, ignoring #124's redirect to `$root_out_dir/cargo_target/`. The engine `rm -rf out` clobber never touches their output.
3. On the persistent **Sandpiper** runner this means stale rlibs from pre-fix builds keep getting reused, masking #123 entirely — every fix attempt has been failing in 29 seconds with the *same* iOS arm64 zstd_sys deployment-target error from a stale `libzstd_sys-*.rlib` that was compiled before the env-var fix existed.

## Fix
Delete the library cargo invocations from all three scripts. Any engine target that depends transitively on `//flutter/shell/common/shorebird:updater` (which is most of them) will now invoke `build_rust_updater.py` via Ninja and produce `libupdater.a` / `updater.lib` in the right place with the right env vars.

The `patch` tool's separate cargo build in `mac_build.sh` / `linux_build.sh` is a standalone CLI, not linked into the engine, so the GN build does not cover it. Left in place with a `TODO` to migrate it later.

## Note for ops
Once this lands, the orphaned `~/.engine_checkout/flutter/engine/src/flutter/third_party/updater/target/` directory on the Sandpiper host should be deleted by hand. It's the stale rlibs that keep masking the fixes. Nothing will write to that path anymore after this PR.

## Known followup not in this PR
`build_rust_updater` action's `outputs = [ _stamp ]` doesn't include `shorebird_updater_output_lib`, which causes a separate ninja error `'cargo_target/.../libupdater.a' missing and no known rule to make it` once the legacy preamble is gone. That's a one-line fix in BUILD.gn — separate PR.

Tracking: shorebirdtech/_shorebird#2014
Follow-up to: #120, #123, #124, #125