### PR TITLE
fix: declare libupdater.a as an output of build_rust_updater action

### DIFF
--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -24,10 +24,18 @@ if (shorebird_updater_supported) {
   action("build_rust_updater") {
     script = "//flutter/shell/common/shorebird/build_rust_updater.py"
 
-    # The stamp file is the declared output for Ninja dependency tracking.
+    # The stamp file gives Ninja a deterministic output to depend on, but
+    # we also have to declare the actual static library so consumers
+    # referencing it via `libs = [ shorebird_updater_output_lib ]` find a
+    # rule that produces it. Without the lib in `outputs`, Ninja errors
+    # with `'cargo_target/.../libupdater.a' missing and no known rule to
+    # make it` once the cargo target dir lives inside root_out_dir (#124).
     _stamp =
         "$target_gen_dir/rust_updater_${shorebird_updater_rust_target}.stamp"
-    outputs = [ _stamp ]
+    outputs = [
+      _stamp,
+      shorebird_updater_output_lib,
+    ]
 
     args = [
       "--rust-target",


### PR DESCRIPTION
## Summary
The `build_rust_updater` action only declared its stamp file as an output, which worked when `shorebird_updater_output_lib` lived under `//flutter/third_party/...` because GN treats source-tree paths as existing files that need no rule. After #124 moved the cargo target dir into `$root_out_dir/cargo_target`, the lib path became a build-dir path and Ninja correctly demands a rule that produces it. Without the lib in `outputs`:

```
ninja: error: 'cargo_target/aarch64-linux-android/release/libupdater.a',
needed by 'libflutter.so', missing and no known rule to make it
```

This was the followup I called out in #127's body — same engine build that exposed it in #127's first run is failing in the same place.

## Fix
Add `shorebird_updater_output_lib` to the action's `outputs` list alongside the stamp file. The cargo invocation already produces the file at this path; this just tells Ninja which rule is responsible.

Tracking: shorebirdtech/_shorebird#2014
Follow-up to: #124, #127