### PR TITLE
ci: upload patch-darwin-arm64.zip alongside x64

### DIFF
--- a/shorebird/ci/internal/mac_upload.sh
+++ b/shorebird/ci/internal/mac_upload.sh
@@ -166,14 +166,16 @@ gsutil cp $ZIPS_OUT/FlutterMacOS.framework.dSYM.zip $ZIPS_DEST/FlutterMacOS.fram
 
 TMP_DIR=$(mktemp -d)
 
-PATCH_VERSION=0.2.1
+PATCH_VERSION=0.3.0
 GH_RELEASE=https://github.com/shorebirdtech/updater/releases/download/patch-v$PATCH_VERSION/
 cd $TMP_DIR
 curl -L $GH_RELEASE/patch-x86_64-apple-darwin.zip -o patch-x86_64-apple-darwin.zip
+curl -L $GH_RELEASE/patch-aarch64-apple-darwin.zip -o patch-aarch64-apple-darwin.zip
 curl -L $GH_RELEASE/patch-x86_64-pc-windows-msvc.zip -o patch-x86_64-pc-windows-msvc.zip
 curl -L $GH_RELEASE/patch-x86_64-unknown-linux-musl.zip -o patch-x86_64-unknown-linux-musl.zip
 
 gsutil cp patch-x86_64-apple-darwin.zip $SHOREBIRD_ROOT/patch-darwin-x64.zip
+gsutil cp patch-aarch64-apple-darwin.zip $SHOREBIRD_ROOT/patch-darwin-arm64.zip
 gsutil cp patch-x86_64-pc-windows-msvc.zip $SHOREBIRD_ROOT/patch-windows-x64.zip
 gsutil cp patch-x86_64-unknown-linux-musl.zip $SHOREBIRD_ROOT/patch-linux-x64.zip
 


### PR DESCRIPTION
Part of https://github.com/shorebirdtech/shorebird/issues/3410

## Summary
- Download the new `patch-aarch64-apple-darwin.zip` asset from the patch release and upload it to GCS as `patch-darwin-arm64.zip`, matching the existing `patch-darwin-x64.zip` naming convention.
- Bumps `PATCH_VERSION` to `0.3.0`, the first release that ships an explicit `aarch64-apple-darwin` asset.

## Context
Apple Silicon users running the Shorebird CLI currently hit `ProcessException: Bad CPU type in executable` when creating patches, because the macOS patch binary was built only for x64 and Rosetta isn't guaranteed to be installed. With this change, `shorebird_cli` can select between `patch-darwin-x64.zip` and `patch-darwin-arm64.zip` based on host architecture.

Depends on shorebirdtech/updater#337, which added the `aarch64-apple-darwin` matrix entry to the `build_patch_artifacts` workflow. That PR has been merged and [`patch-v0.3.0`](https://github.com/shorebirdtech/updater/releases/tag/patch-v0.3.0) has been cut with all four expected assets:
- `patch-x86_64-unknown-linux-musl.zip`
- `patch-x86_64-apple-darwin.zip`
- `patch-aarch64-apple-darwin.zip` (new)
- `patch-x86_64-pc-windows-msvc.zip`

The new arm64 asset has been locally verified: `file` reports `Mach-O 64-bit executable arm64`, it runs natively on Apple Silicon without Rosetta, and a smoke-test diff between two text files produced the expected zstd-compressed bidiff output.

A follow-up change in `shorebird_cli/lib/src/cache.dart` will teach `PatchArtifact.storageUrl` to pick the arm64 asset on Apple Silicon hosts.

## Test plan
- [x] Confirm both `patch-x86_64-apple-darwin.zip` and `patch-aarch64-apple-darwin.zip` are present as release assets on `patch-v0.3.0`.
- [x] Verify the arm64 binary is natively compiled (`file` reports `Mach-O 64-bit executable arm64`) and runs on Apple Silicon.
- [ ] After an engine build, confirm `gs://download.shorebird.dev/shorebird/<engine_hash>/patch-darwin-arm64.zip` exists.