### PR TITLE
chore: roll updater to 8459296

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@ vars = {
   "dart_sdk_revision": "667fc4ab87165889877a529f72c17bdb3b36738d",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "adacb4190cb4af2e2920c18d8a904f4c6b138ee4",
+  "updater_rev": "8459296d7267f0e761f48070c1ed374a5559a2c2",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.


### PR DESCRIPTION
Rolls `shorebirdtech/updater` `adacb41..8459296` (5 commits) before cutting the engine for release.

## Notable changes
- fix: do not throw UpdateException on SHOREBIRD_NO_UPDATE (shorebirdtech/updater#334)
- fix: return UpdateInProgress status instead of erroring when another update is running (shorebirdtech/updater#335)
- ci: build patch binary for aarch64-apple-darwin (shorebirdtech/updater#337)
- chore(deps): update sha2 requirement in /patch in the patch-deps group (shorebirdtech/updater#330)
- chore(deps): bump the gh-deps group with 2 updates (shorebirdtech/updater#331)

Diff: https://github.com/shorebirdtech/updater/compare/adacb4190cb4af2e2920c18d8a904f4c6b138ee4...8459296d7267f0e761f48070c1ed374a5559a2c2

The previous updater roll (#122) plus the six GN/build fixes (#123 #124 #125 #127 #128 #130) just produced the first fully-green engine build against the new ureq-based updater. This roll picks up the two semantic fixes and three housekeeping commits that landed on updater main since then. We'll rebuild the engine against this on the way to cutting the release.