### PR TITLE
feat: add --shorebird-trace support to aar, ios-framework, and macos builds

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -50,6 +50,7 @@ class BuildAarCommand extends BuildSubCommand {
     usesTrackWidgetCreation(verboseHelp: false);
     addEnableExperimentation(hide: !verboseHelp);
     addAndroidSpecificBuildOptions(hide: !verboseHelp);
+    usesShorebirdTraceOption(hide: !verboseHelp);
     argParser.addMultiOption(
       'target-platform',
       defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -47,6 +47,7 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     addDartObfuscationOption();
     usesExtraDartFlagOptions(verboseHelp: verboseHelp);
     addEnableExperimentation(hide: !verboseHelp);
+    usesShorebirdTraceOption(hide: !verboseHelp);
 
     argParser
       ..addFlag(

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -18,6 +18,7 @@ class BuildMacosCommand extends BuildSubCommand {
     : super(verboseHelp: verboseHelp) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
     usesFlavorOption();
+    usesShorebirdTraceOption(hide: !verboseHelp);
     argParser.addFlag(
       'config-only',
       help:


### PR DESCRIPTION
## Summary

The `--shorebird-trace` flag was added in #116 for `flutter build appbundle`, `flutter build apk`, and `flutter build ios`, but was not wired up for:

- `flutter build aar` (Android add-to-app)
- `flutter build ios-framework` (iOS add-to-app)
- `flutter build macos`

The shorebird CLI passes `--shorebird-trace` for all platforms when tracing is enabled (Flutter >= 3.41.7), causing these builds to fail with `Could not find an option named "--shorebird-trace"`.

## Changes

Added `usesShorebirdTraceOption(hide: !verboseHelp)` to `BuildAarCommand`, `BuildFrameworkCommand` (ios-framework), and `BuildMacosCommand` constructors — the same one-liner already present in the other build commands.

## Test plan

- [x] Discovered during 3.41.7 release smoke testing: add-to-app and macOS tests fail without this fix
- [x] The option registration follows the identical pattern already used in `build_appbundle.dart`, `build_apk.dart`, and `build_ios.dart`