### PR TITLE
refactor: split shorebird C API consumption (engine side of updater #350)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@ vars = {
   "dart_sdk_revision": "3f8b97e369a83033089608c86c996a3f67897f8c",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "10aaca0f8bf615b388be9d700a63765c45cade4b",
+  "updater_rev": "34509fca3c65388ebc84cfaea8f38733ce41f41a",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/engine/src/flutter/shell/common/shorebird/updater.cc
+++ b/engine/src/flutter/shell/common/shorebird/updater.cc
@@ -7,7 +7,7 @@
 #include "flutter/fml/logging.h"
 
 #if SHOREBIRD_PLATFORM_SUPPORTED
-#include "third_party/updater/library/include/updater.h"
+#include "third_party/updater/library/include/updater_engine.h"
 #endif
 
 namespace flutter {

--- a/engine/src/flutter/shell/platform/android/android_exports.lst
+++ b/engine/src/flutter/shell/platform/android/android_exports.lst
@@ -12,13 +12,9 @@
     InternalFlutterGpu*;
     kInternalFlutterGpu*;
     shorebird_init;
-    shorebird_active_path;
-    shorebird_active_patch_number;
     shorebird_free_string;
     shorebird_free_update_result;
     shorebird_check_for_downloadable_update;
-    shorebird_check_for_update;
-    shorebird_update;
     shorebird_update_with_result;
     shorebird_next_boot_patch_number;
     shorebird_current_boot_patch_number;


### PR DESCRIPTION
## Summary

Engine-side companion to [shorebirdtech/updater#350](https://github.com/shorebirdtech/updater/pull/350), which splits `library/src/c_api` into `dart` and `engine` submodules and replaces the combined `updater.h` with `updater_dart.h` + `updater_engine.h`.

- `engine/src/flutter/shell/common/shorebird/updater.cc` — switch the include from `updater.h` (deleted in #350) to `updater_engine.h`.
- `engine/src/flutter/shell/platform/android/android_exports.lst` — drop four entries that no longer exist in the Rust crate after #350:
  - `shorebird_active_path`, `shorebird_active_patch_number` — ghost entries; they never existed in Rust and were already dead before #350.
  - `shorebird_check_for_update`, `shorebird_update` — both removed in #350, replaced by `shorebird_check_for_downloadable_update` and `shorebird_update_with_result` respectively.
- `DEPS` — bump `updater_rev` to `34509fca3c65388ebc84cfaea8f38733ce41f41a`, the merge commit of #350 on updater \`main\`.

The follow-up checklist on #350 listed three drops; I also dropped `shorebird_update` for the same reason (the symbol no longer exists post-#350). Worth confirming in review.

## Why

Two commits, kept separate so each is easy to re-review:

1. The include + exports change, written before #350 landed.
2. The `updater_rev` bump, added now that #350 is on updater `main` at `34509fca3c`.

## Test plan

- [x] Wait for #350 to merge, then bump `updater_rev` in `DEPS` to its merge SHA.
- [ ] Local engine build (Android target) — verify libflutter.so links and the dropped exports cause no missing-symbol errors at link or runtime.
- [ ] Smoke test: build a `shorebird preview` app against this engine and confirm patch download + reporting still work.

## Coordination

shorebirdtech/updater#350 landed at `34509fca3c`; this PR is no longer blocked.