### PR TITLE
ci: add aggregator job for branch protection

### DIFF
--- a/.github/workflows/shorebird_ci.yml
+++ b/.github/workflows/shorebird_ci.yml
@@ -141,3 +141,19 @@ jobs:
         env:
           # Enables streaming subprocess output for debugging timeouts.
           VERBOSE: "1"
+
+  # Aggregator required by branch protection on shorebird/dev so the rule can
+  # list a single context ("ci") instead of every matrix-expanded job above.
+  ci:
+    if: always()
+    needs:
+      - flutter-tools-tests
+      - shard-runner-tests
+      - shorebird-android-tests
+      - shorebird-ios-tests
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
## Summary

Add a single `ci` job to `.github/workflows/shorebird_ci.yml` that depends on the four real test jobs and fails if any of them failed or were cancelled. The job has no matrix and no emoji in its name, so the check shows up on PRs as a stable context named `ci`.

## Why

`shorebird/dev` currently has no branch protection (`gh api .../branches/shorebird/dev/protection` → 404), so GitHub never offers an "Enable auto-merge" button — every approved PR is immediately mergeable, with no required check to wait on.

Sister repos (`shorebirdtech/updater`, `shorebirdtech/_shorebird`) protect `main` with a single required context: `["ci"]`. Mirroring that pattern here is the goal, but this repo doesn't have an equivalent umbrella check — the existing CI is five matrix-expanded jobs whose names contain emoji and matrix axes, so listing them directly in branch protection would silently let PRs through any time a job is renamed or matrix axis tweaked.

This PR adds the umbrella. The follow-up section below is the runbook for adding the actual branch-protection rule once this lands.

## Conflict surface vs. upstream

`.github/workflows/shorebird_ci.yml` is unambiguously a Shorebird-owned file (Shorebird-themed jobs, paths into `packages/shorebird_tests` and `shorebird/ci/shard_runner/`), so editing it doesn't widen the conflict surface against future `flutter/flutter` upstream merges. The upstream `ci.yml` has a single job named `test`, so no name collision with the new `ci` job.

## Test plan

- [ ] Verify on this PR that a check named `ci` appears in the rollup and turns green once the four upstream jobs pass.
- [ ] Force a failure (e.g. on a throwaway PR) in one of the upstream jobs and confirm `ci` reports failure rather than success.

## Follow-up: enable branch protection on `shorebird/dev`

Once this PR lands and the `ci` check has appeared on at least one PR (so GitHub has it in its known-contexts list), apply protection mirroring `updater` / `_shorebird`:

```bash
gh api -X PUT 'repos/shorebirdtech/flutter/branches/shorebird/dev/protection' --input - <<'JSON'
{
  "required_status_checks": {
    "strict": true,
    "contexts": ["ci"]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": {
    "dismiss_stale_reviews": false,
    "require_code_owner_reviews": false,
    "required_approving_review_count": 1
  },
  "restrictions": null,
  "required_conversation_resolution": true,
  "allow_force_pushes": false,
  "allow_deletions": false
}
JSON
```

Verify it took:

```bash
gh api repos/shorebirdtech/flutter/branches/shorebird/dev/protection
```

UI equivalent: Settings → Branches → "Add classic branch protection rule" → branch name pattern `shorebird/dev` → tick:
- Require a pull request before merging (1 approval; *don't* require code owners; *don't* dismiss stale reviews)
- Require status checks to pass (require branches to be up to date; add `ci`)
- Require conversation resolution before merging
- Leave "Do not allow bypassing the above settings" **unchecked** (admins can override, matching sister repos)
- Leave force pushes and deletions disabled

Sanity check after applying: open a fresh PR against `shorebird/dev` and confirm the **Enable auto-merge** dropdown now appears next to the merge button.
