### PR TITLE
fix: update build_rust_updater cbindgen inputs after #350 API split

### DIFF
--- a/engine/src/flutter/shell/common/shorebird/BUILD.gn
+++ b/engine/src/flutter/shell/common/shorebird/BUILD.gn
@@ -86,7 +86,8 @@ if (shorebird_updater_supported) {
       "$shorebird_updater_dir/Cargo.lock",
       "$shorebird_updater_dir/library/Cargo.toml",
       "$shorebird_updater_dir/library/build.rs",
-      "$shorebird_updater_dir/library/cbindgen.toml",
+      "$shorebird_updater_dir/library/cbindgen_dart.toml",
+      "$shorebird_updater_dir/library/cbindgen_engine.toml",
       "$shorebird_updater_dir/library/.cargo/config.toml",
     ]
     inputs += shorebird_updater_rs_sources


### PR DESCRIPTION
## Summary

- Replace the deleted `library/cbindgen.toml` input with the split `library/cbindgen_dart.toml` and `library/cbindgen_engine.toml`, restoring shorebird-runtime iOS engine builds on `shorebird/dev`.

## Context

[#138](https://github.com/shorebirdtech/flutter/pull/138) (refactor: split shorebird C API consumption) switched `shell/common/shorebird/updater.cc` to the new `updater_engine.h` header. The matching DEPS bump pulled the updater repo state from [shorebirdtech/updater#350](https://github.com/shorebirdtech/updater/pull/350) where the combined `library/cbindgen.toml` was replaced with separate `library/cbindgen_dart.toml` and `library/cbindgen_engine.toml`.

The `build_rust_updater` action's declared inputs in `shell/common/shorebird/BUILD.gn` weren't updated to match, so iOS engine builds on `shorebird/dev` fail with:

```
ninja: error: '../../flutter/third_party/updater/library/cbindgen.toml',
needed by 'gen/flutter/shell/common/shorebird/rust_updater_<...>.stamp',
missing and no known rule to make it
```

This action only runs in shorebird-runtime engine builds, which the periodic `_build_engine` workflow exercises but no per-PR CI job does, so the regression went unnoticed.

## Test plan

- [ ] Local: `./build_local_engine.sh` (or equivalent `gn`+`ninja -C out/ios_release flutter/lib/snapshot:generate_snapshot_bins flutter/shell/platform/darwin/ios:flutter_framework`) succeeds where it previously failed at the `rust_updater_<arch>.stamp` step.
- [ ] Verified locally: full iOS engine build on top of this fix succeeded; produced `Flutter.framework` and `gen_snapshot` were used to publish a Wonderous release end-to-end.