### PR TITLE
fix: honor --flavor for ios-framework builds

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -338,6 +338,11 @@ class BuildInfo {
       kFileSystemScheme: ?fileSystemScheme,
       kBuildName: ?buildName,
       kBuildNumber: ?buildNumber,
+      // TODO(eseidel): Remove when flutter/flutter#186221 lands. Without
+      // this line --flavor doesn't reach CopyAssets for
+      // `flutter build ios-framework`, which silently breaks both
+      // flavor-conditional assets and shorebird.yaml flavor compilation.
+      kFlavor: ?flavor,
       if (useLocalCanvasKit) kUseLocalCanvasKitFlag: useLocalCanvasKit.toString(),
     };
   }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -338,10 +338,6 @@ class BuildInfo {
       kFileSystemScheme: ?fileSystemScheme,
       kBuildName: ?buildName,
       kBuildNumber: ?buildNumber,
-      // TODO(eseidel): Remove when flutter/flutter#186221 lands. Without
-      // this line --flavor doesn't reach CopyAssets for
-      // `flutter build ios-framework`, which silently breaks both
-      // flavor-conditional assets and shorebird.yaml flavor compilation.
       kFlavor: ?flavor,
       if (useLocalCanvasKit) kUseLocalCanvasKitFlag: useLocalCanvasKit.toString(),
     };

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -224,7 +224,7 @@ void main() {
   testWithoutContext('toBuildSystemEnvironment encoding of standard values', () {
     const buildInfo = BuildInfo(
       BuildMode.debug,
-      '',
+      'strawberry',
       treeShakeIcons: true,
       trackWidgetCreation: true,
       dartDefines: <String>['foo=2', 'bar=2'],
@@ -256,7 +256,19 @@ void main() {
       'FileSystemScheme': 'scheme',
       'BuildName': '122',
       'BuildNumber': '22',
+      'Flavor': 'strawberry',
     });
+  });
+
+  testWithoutContext('toBuildSystemEnvironment omits Flavor when flavor is null', () {
+    const buildInfo = BuildInfo(
+      BuildMode.release,
+      null,
+      treeShakeIcons: false,
+      packageConfigPath: '.dart_tool/package_config.json',
+    );
+
+    expect(buildInfo.toBuildSystemEnvironment().containsKey('Flavor'), isFalse);
   });
 
   testWithoutContext('toEnvironmentConfig encoding of standard values', () {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -224,6 +224,67 @@ flutter:
     },
   );
 
+  group('CopyAssets compiles shorebird.yaml using the environment flavor', () {
+    const shorebirdYamlContents = '''
+app_id: base-app-id
+flavors:
+  internal: internal-app-id
+  stable: stable-app-id
+''';
+
+    void writeProjectWithShorebirdYaml() {
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+name: example
+flutter:
+  assets:
+    - shorebird.yaml
+''');
+      fileSystem.file('shorebird.yaml')
+        ..createSync()
+        ..writeAsStringSync(shorebirdYamlContents);
+      writePackageConfigFiles(directory: globals.fs.currentDirectory, mainLibName: 'example');
+    }
+
+    testUsingContext(
+      'falls back to top-level app_id when no flavor is set',
+      () async {
+        writeProjectWithShorebirdYaml();
+
+        await const CopyAssets().build(environment);
+
+        final File compiled = fileSystem.file(
+          '${environment.buildDir.path}/flutter_assets/shorebird.yaml',
+        );
+        expect(compiled.readAsStringSync(), 'app_id: base-app-id');
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'uses the flavor app_id when flavor is set',
+      () async {
+        environment.defines[kFlavor] = 'internal';
+        writeProjectWithShorebirdYaml();
+
+        await const CopyAssets().build(environment);
+
+        final File compiled = fileSystem.file(
+          '${environment.buildDir.path}/flutter_assets/shorebird.yaml',
+        );
+        expect(compiled.readAsStringSync(), 'app_id: internal-app-id');
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+  });
+
   testUsingContext(
     'transforms assets declared with transformers',
     () async {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -716,6 +716,75 @@ void main() {
   );
 
   testUsingContext(
+    'ReleaseIosApplicationBundle compiles shorebird.yaml using the flavor app_id',
+    () async {
+      environment.defines[kBuildMode] = 'release';
+      environment.defines[kXcodeAction] = 'install';
+      environment.defines[kFlavor] = 'internal';
+
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+name: example
+flutter:
+  assets:
+    - shorebird.yaml
+''');
+
+      fileSystem.file('shorebird.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+app_id: base-app-id
+flavors:
+  internal: internal-app-id
+  stable: stable-app-id
+''');
+
+      writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'example');
+
+      fileSystem
+          .file(fileSystem.path.join('ios', 'Flutter', 'AppFrameworkInfo.plist'))
+          .createSync(recursive: true);
+      environment.buildDir
+          .childDirectory('App.framework')
+          .childFile('App')
+          .createSync(recursive: true);
+      environment.buildDir.childFile('native_assets.json').createSync();
+
+      final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
+      final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
+      final File infoPlist = frameworkDirectory.childFile('Info.plist');
+      processManager.addCommands(<FakeCommand>[
+        createPlutilFakeCommand(infoPlist),
+        FakeCommand(
+          command: <String>[
+            'xattr',
+            '-r',
+            '-d',
+            'com.apple.FinderInfo',
+            frameworkDirectoryBinary.path,
+          ],
+        ),
+        FakeCommand(
+          command: <String>['codesign', '--force', '--sign', '-', frameworkDirectoryBinary.path],
+        ),
+      ]);
+
+      await const ReleaseIosApplicationBundle().build(environment);
+
+      final File compiledYaml = frameworkDirectory
+          .childDirectory('flutter_assets')
+          .childFile('shorebird.yaml');
+      expect(compiledYaml.readAsStringSync(), 'app_id: internal-app-id');
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Platform: () => macPlatform,
+    },
+  );
+
+  testUsingContext(
     'AotAssemblyRelease throws exception if asked to build for simulator',
     () async {
       final FileSystem fileSystem = MemoryFileSystem.test();


### PR DESCRIPTION
## Summary

`flutter build ios-framework --flavor X` was silently dropping `--flavor` before the asset bundling step ran, so flavor-conditional assets and the compiled `shorebird.yaml`'s app_id always fell back to the top-level (non-flavor) value.

The same gap exists upstream — tracked at flutter/flutter#186220 with proposed fix flutter/flutter#186221. This is the matching fix carried temporarily on the fork until upstream lands. The TODO on the changed line points at the upstream PR so a future fork-sync drops it cleanly.

Concretely: `BuildIOSFrameworkCommand._produceAppFramework` builds its `Environment` directly from `BuildInfo.toBuildSystemEnvironment()`, which was missing the `kFlavor` entry. So `environment.defines[kFlavor]` was always `null` when `CopyAssets` ran, and the flavor filter (and `compileShorebirdYaml`) fell through to "no flavor".

End-to-end reproduction on vanilla stable Flutter: https://github.com/eseidel/flavor_bundle_repro

## Test plan

- [x] Existing `toBuildSystemEnvironment encoding of standard values` test now exercises a non-null flavor and asserts `Flavor` is included; added a sibling test asserting the key is omitted when flavor is null.
- [x] New shorebird-fork-only tests for `compileShorebirdYaml` flavor compilation:
  - `CopyAssets compiles shorebird.yaml using the environment flavor` — covers the shared codepath used by every platform.
  - `ReleaseIosApplicationBundle compiles shorebird.yaml using the flavor app_id` — covers the iOS-framework-specific asset bundle target.
- [x] All existing tests continue to pass (86/86 in the affected files).

## Companion PR

shorebirdtech/shorebird#3748 forwards `--flavor` from the Shorebird CLI's `aar_releaser` / `ios_framework_releaser` to `flutter build`. Both PRs are needed to fully fix the iOS-framework case for customers; AAR is fixed by the CLI PR alone (Gradle plugin propagates the flavor independently).