### PR TITLE
fix: drop stale shorebird_check_for_update/shorebird_update from Windows .def

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_windows.dll.def
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.dll.def
@@ -1,6 +1,5 @@
 EXPORTS
   shorebird_check_for_downloadable_update = shorebird_check_for_downloadable_update
-  shorebird_check_for_update = shorebird_check_for_update
   shorebird_current_boot_patch_number = shorebird_current_boot_patch_number
   shorebird_free_string = shorebird_free_string
   shorebird_free_update_result = shorebird_free_update_result
@@ -13,5 +12,4 @@ EXPORTS
   shorebird_report_launch_success = shorebird_report_launch_success
   shorebird_should_auto_update = shorebird_should_auto_update
   shorebird_start_update_thread = shorebird_start_update_thread
-  shorebird_update = shorebird_update
   shorebird_update_with_result = shorebird_update_with_result


### PR DESCRIPTION
## Summary
- Remove `shorebird_check_for_update` and `shorebird_update` from `flutter_windows.dll.def`. Both symbols were removed in updater [#350](https://github.com/shorebirdtech/updater/pull/350) (replaced by `shorebird_check_for_downloadable_update` and `shorebird_update_with_result` respectively).
- Mirrors the Android equivalent cleanup done in [#138](https://github.com/shorebirdtech/flutter/pull/138) (the `android_exports.lst` was updated there but the Windows `.def` was missed).

## Context
The 3.41.9-rc2 engine build is failing the Windows linker step:
```
flutter_windows.dll.def : error LNK2001: unresolved external symbol shorebird_check_for_update
flutter_windows.dll.def : error LNK2001: unresolved external symbol shorebird_update
./flutter_windows.dll.lib : fatal error LNK1120: 2 unresolved externals
```
Build log: https://github.com/shorebirdtech/_build_engine/actions/runs/25527410414/job/74926049985

The replacements (`shorebird_check_for_downloadable_update` and `shorebird_update_with_result`) are already exported in this same `.def` file, so removing the stale entries is the entire fix.

## Test plan
- [ ] Re-trigger engine build at this commit; Windows job links successfully.