### PR TITLE
ci(shorebird): drop iOS Rust targets from macOS android shard

### DIFF
--- a/shorebird/ci/shards/macos.json
+++ b/shorebird/ci/shards/macos.json
@@ -4,8 +4,6 @@
       {
         "type": "rust",
         "targets": [
-          "aarch64-apple-ios",
-          "x86_64-apple-ios",
           "aarch64-apple-darwin",
           "x86_64-apple-darwin"
         ]


### PR DESCRIPTION
## Summary
The macOS `android` shard's Rust step lists `aarch64-apple-ios` and
`x86_64-apple-ios` alongside the host darwin targets. Those iOS targets
aren't used by anything the android shard links — gen_snapshot is built
for the host (the gn args force `host_cpu="x64"`). They're left over
from the old monolithic `mac_setup.sh` that built every macOS variant
in one script.

## Why this matters now
On the namespace.so macOS Sequoia runner, building updater for
`aarch64-apple-ios` via cargo trips an iOS SDK / deployment-target
mismatch and fails the shard outright. Removing the unused targets lets
the android shard go green.

The actual `ios-release` shards still need the iOS Rust targets;
the SDK pin for those is handled separately in `_build_engine`
(`IPHONEOS_DEPLOYMENT_TARGET=13.0`).

## Test plan
- [ ] Bump engine SHA (or wait for next bump) so `_build_engine`'s
      sharded workflow checks out a tree containing this fix
- [ ] Re-trigger sharded build; android shard passes