### PR TITLE
ci(shorebird): stream child stdout/stderr from shard_runner

### DIFF
--- a/shorebird/ci/shard_runner/lib/gcs.dart
+++ b/shorebird/ci/shard_runner/lib/gcs.dart
@@ -80,10 +80,8 @@ Future<void> downloadFromStaging({
     description: 'gsutil ls $stagingRoot',
   );
 
-  final List<String> files = lsOutput
-      .split('\n')
-      .where((String f) => f.endsWith('.tar.gz'))
-      .toList();
+  final List<String> files =
+      lsOutput.split('\n').where((String f) => f.endsWith('.tar.gz')).toList();
 
   for (final String file in files) {
     final String fileName = p.basename(file);

--- a/shorebird/ci/shard_runner/lib/gcs.dart
+++ b/shorebird/ci/shard_runner/lib/gcs.dart
@@ -72,14 +72,15 @@ Future<void> downloadFromStaging({
 
   print('[GCS] Downloading from $stagingRoot');
 
-  // List files in the staging location
-  final ProcessResult lsResult = await runChecked(
+  // List files in the staging location. We capture stdout because we need
+  // to parse the file list; everything else uses runChecked to stream.
+  final String lsOutput = await runCapturingStdout(
     'gsutil',
     <String>['ls', stagingRoot],
     description: 'gsutil ls $stagingRoot',
   );
 
-  final List<String> files = (lsResult.stdout as String)
+  final List<String> files = lsOutput
       .split('\n')
       .where((String f) => f.endsWith('.tar.gz'))
       .toList();

--- a/shorebird/ci/shard_runner/lib/process.dart
+++ b/shorebird/ci/shard_runner/lib/process.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 /// Resolves an executable name for Windows, appending .cmd if needed.
@@ -28,10 +30,13 @@ String _resolveExecutable(String executable) {
   return executable;
 }
 
-/// Runs a process and throws if it exits with a non-zero code.
+/// Runs a process, streaming stdout/stderr to the parent's stdio so the
+/// caller (and CI logs) see output live. Throws if the process exits
+/// non-zero.
 ///
-/// Returns the [ProcessResult] for callers that need stdout/stderr.
-Future<ProcessResult> runChecked(
+/// Use this for everything except the rare case where you need to parse
+/// the child's stdout — for that, see [runCapturingStdout].
+Future<void> runChecked(
   String executable,
   List<String> arguments, {
   String? workingDirectory,
@@ -40,27 +45,59 @@ Future<ProcessResult> runChecked(
 }) async {
   final String resolvedExecutable = _resolveExecutable(executable);
 
-  final ProcessResult result = await Process.run(
+  final Process process = await Process.start(
+    resolvedExecutable,
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    mode: ProcessStartMode.inheritStdio,
+  );
+
+  final int exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    final String desc = description ?? '$executable ${arguments.join(' ')}';
+    throw Exception('$desc failed (exit $exitCode)');
+  }
+}
+
+/// Runs a process, capturing stdout into the returned string while still
+/// streaming stderr to the parent's stderr. Throws if the process exits
+/// non-zero.
+///
+/// Use this when you need to parse the child's stdout (e.g. `gsutil ls`).
+/// For everything else use [runChecked] so output reaches the CI log live.
+Future<String> runCapturingStdout(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+  Map<String, String>? environment,
+  String? description,
+}) async {
+  final String resolvedExecutable = _resolveExecutable(executable);
+
+  final Process process = await Process.start(
     resolvedExecutable,
     arguments,
     workingDirectory: workingDirectory,
     environment: environment,
   );
 
-  if (result.exitCode != 0) {
-    final String desc = description ?? '$executable ${arguments.join(' ')}';
-    final String stderr = (result.stderr as String).trim();
-    final String stdout = (result.stdout as String).trim();
-    final StringBuffer message =
-        StringBuffer('$desc failed (exit ${result.exitCode})');
-    if (stdout.isNotEmpty) {
-      message.write('\nSTDOUT: $stdout');
-    }
-    if (stderr.isNotEmpty) {
-      message.write('\nSTDERR: $stderr');
-    }
-    throw Exception(message.toString());
-  }
+  final Future<String> stdoutFuture =
+      process.stdout.transform(utf8.decoder).join();
+  final Future<void> stderrFuture =
+      process.stderr.transform(utf8.decoder).forEach(stderr.write);
 
-  return result;
+  final List<Object?> results = await Future.wait<Object?>(<Future<Object?>>[
+    stdoutFuture,
+    stderrFuture,
+    process.exitCode,
+  ]);
+  final String capturedStdout = results[0] as String;
+  final int exitCode = results[2] as int;
+
+  if (exitCode != 0) {
+    final String desc = description ?? '$executable ${arguments.join(' ')}';
+    throw Exception('$desc failed (exit $exitCode)');
+  }
+  return capturedStdout;
 }


### PR DESCRIPTION
## Summary
`runChecked` used `Process.run`, which buffers stdout/stderr in memory
and only emits anything on a non-zero exit — and on success, nothing at
all. The result: 30+ minutes of `ninja`, `cargo`, and `gclient` output
per shard never reached the GitHub Actions log. Only the runner's own
`[Step] starting` / `[Step] complete` prints made it through, so a
healthy shard looked like a frozen one.

The legacy `mac_build.sh` / `linux_build.sh` scripts streamed naturally
(plain bash invocations of `\$NINJA -C ...`), so this was a regression
the sharded runner introduced.

## Change
- `runChecked` now uses `Process.start` with `ProcessStartMode.inheritStdio`,
  so child stdout/stderr go live to the parent's stdio (and thus the CI
  log). On failure the exception just notes the exit code — captured
  output is no longer included because it already streamed.
- New `runCapturingStdout` for the one place that actually parses child
  output (`gsutil ls` in `lib/gcs.dart`). It captures stdout while
  still streaming stderr.
- `lib/gcs.dart` updated to use it.

## Test plan
- [x] `dart analyze` clean
- [x] `dart test` (32/32 pass)
- [ ] Trigger sharded build in `_build_engine`; verify ninja `[N/M]`
      progress lines and cargo per-target output appear live in the
      GHA log