### PR TITLE
ci(shorebird): add dst + artifacts to compose.json; mac framework artifact

### DIFF
--- a/shorebird/ci/compose.json
+++ b/shorebird/ci/compose.json
@@ -7,7 +7,11 @@
       "--arm64-out-dir": "ios_release",
       "--simulator-x64-out-dir": "ios_debug_sim",
       "--simulator-arm64-out-dir": "ios_debug_sim_arm64"
-    }
+    },
+    "artifacts": [
+      {"src": "artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/ios-release/artifacts.zip"},
+      {"src": "Flutter.framework.dSYM.zip", "dst": "flutter_infra_release/flutter/$engine/ios-release/Flutter.framework.dSYM.zip"}
+    ]
   },
   "macos-framework": {
     "requires": ["mac-arm64", "mac-x64"],
@@ -16,7 +20,11 @@
     "path_args": {
       "--arm64-out-dir": "mac_release_arm64",
       "--x64-out-dir": "mac_release"
-    }
+    },
+    "artifacts": [
+      {"src": "FlutterMacOS.framework.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/FlutterMacOS.framework.zip"},
+      {"src": "FlutterMacOS.framework.dSYM.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64/FlutterMacOS.framework.dSYM.zip"}
+    ]
   },
   "macos-gen-snapshot": {
     "requires": ["mac-arm64", "mac-x64"],
@@ -25,6 +33,10 @@
     "path_args": {
       "--arm64-path": "mac_release_arm64/universal/gen_snapshot_arm64",
       "--x64-path": "mac_release/universal/gen_snapshot_x64"
-    }
+    },
+    "dst": "release/snapshot",
+    "artifacts": [
+      {"src": "snapshot/gen_snapshot.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/gen_snapshot.zip"}
+    ]
   }
 }

--- a/shorebird/ci/shards/linux.json
+++ b/shorebird/ci/shards/linux.json
@@ -13,12 +13,12 @@
       }
     ],
     "artifacts": [
-      {"src": "zip_archives/android-arm64-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/artifacts.zip"},
-      {"src": "zip_archives/android-arm64-release/linux-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/linux-x64.zip"},
-      {"src": "zip_archives/android-arm64-release/symbols.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/symbols.zip"},
-      {"src": "arm64_v8a_release.pom", "dst": "download.flutter.io/io/flutter/arm64_v8a_release/1.0.0-$engine/arm64_v8a_release-1.0.0-$engine.pom"},
-      {"src": "arm64_v8a_release.jar", "dst": "download.flutter.io/io/flutter/arm64_v8a_release/1.0.0-$engine/arm64_v8a_release-1.0.0-$engine.jar"},
-      {"src": "arm64_v8a_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/arm64_v8a_release/1.0.0-$engine/arm64_v8a_release-1.0.0-$engine.maven-metadata.xml"}
+      {"src": "android_release_arm64/zip_archives/android-arm64-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/artifacts.zip"},
+      {"src": "android_release_arm64/zip_archives/android-arm64-release/linux-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/linux-x64.zip"},
+      {"src": "android_release_arm64/zip_archives/android-arm64-release/symbols.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/symbols.zip"},
+      {"src": "android_release_arm64/arm64_v8a_release.pom", "dst": "download.flutter.io/io/flutter/arm64_v8a_release/1.0.0-$engine/arm64_v8a_release-1.0.0-$engine.pom"},
+      {"src": "android_release_arm64/arm64_v8a_release.jar", "dst": "download.flutter.io/io/flutter/arm64_v8a_release/1.0.0-$engine/arm64_v8a_release-1.0.0-$engine.jar"},
+      {"src": "android_release_arm64/arm64_v8a_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/arm64_v8a_release/1.0.0-$engine/arm64_v8a_release-1.0.0-$engine.maven-metadata.xml"}
     ]
   },
   "android-arm32": {
@@ -35,15 +35,15 @@
       }
     ],
     "artifacts": [
-      {"src": "zip_archives/android-arm-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/artifacts.zip"},
-      {"src": "zip_archives/android-arm-release/linux-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/linux-x64.zip"},
-      {"src": "zip_archives/android-arm-release/symbols.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/symbols.zip"},
-      {"src": "armeabi_v7a_release.pom", "dst": "download.flutter.io/io/flutter/armeabi_v7a_release/1.0.0-$engine/armeabi_v7a_release-1.0.0-$engine.pom"},
-      {"src": "armeabi_v7a_release.jar", "dst": "download.flutter.io/io/flutter/armeabi_v7a_release/1.0.0-$engine/armeabi_v7a_release-1.0.0-$engine.jar"},
-      {"src": "armeabi_v7a_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/armeabi_v7a_release/1.0.0-$engine/armeabi_v7a_release-1.0.0-$engine.maven-metadata.xml"},
-      {"src": "flutter_embedding_release.pom", "dst": "download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-$engine/flutter_embedding_release-1.0.0-$engine.pom"},
-      {"src": "flutter_embedding_release.jar", "dst": "download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-$engine/flutter_embedding_release-1.0.0-$engine.jar"},
-      {"src": "flutter_embedding_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-$engine/flutter_embedding_release-1.0.0-$engine.maven-metadata.xml"}
+      {"src": "android_release/zip_archives/android-arm-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/artifacts.zip"},
+      {"src": "android_release/zip_archives/android-arm-release/linux-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/linux-x64.zip"},
+      {"src": "android_release/zip_archives/android-arm-release/symbols.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/symbols.zip"},
+      {"src": "android_release/armeabi_v7a_release.pom", "dst": "download.flutter.io/io/flutter/armeabi_v7a_release/1.0.0-$engine/armeabi_v7a_release-1.0.0-$engine.pom"},
+      {"src": "android_release/armeabi_v7a_release.jar", "dst": "download.flutter.io/io/flutter/armeabi_v7a_release/1.0.0-$engine/armeabi_v7a_release-1.0.0-$engine.jar"},
+      {"src": "android_release/armeabi_v7a_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/armeabi_v7a_release/1.0.0-$engine/armeabi_v7a_release-1.0.0-$engine.maven-metadata.xml"},
+      {"src": "android_release/flutter_embedding_release.pom", "dst": "download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-$engine/flutter_embedding_release-1.0.0-$engine.pom"},
+      {"src": "android_release/flutter_embedding_release.jar", "dst": "download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-$engine/flutter_embedding_release-1.0.0-$engine.jar"},
+      {"src": "android_release/flutter_embedding_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-$engine/flutter_embedding_release-1.0.0-$engine.maven-metadata.xml"}
     ]
   },
   "android-x64": {
@@ -60,12 +60,12 @@
       }
     ],
     "artifacts": [
-      {"src": "zip_archives/android-x64-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/artifacts.zip"},
-      {"src": "zip_archives/android-x64-release/linux-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/linux-x64.zip"},
-      {"src": "zip_archives/android-x64-release/symbols.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/symbols.zip"},
-      {"src": "x86_64_release.pom", "dst": "download.flutter.io/io/flutter/x86_64_release/1.0.0-$engine/x86_64_release-1.0.0-$engine.pom"},
-      {"src": "x86_64_release.jar", "dst": "download.flutter.io/io/flutter/x86_64_release/1.0.0-$engine/x86_64_release-1.0.0-$engine.jar"},
-      {"src": "x86_64_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/x86_64_release/1.0.0-$engine/x86_64_release-1.0.0-$engine.maven-metadata.xml"}
+      {"src": "android_release_x64/zip_archives/android-x64-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/artifacts.zip"},
+      {"src": "android_release_x64/zip_archives/android-x64-release/linux-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/linux-x64.zip"},
+      {"src": "android_release_x64/zip_archives/android-x64-release/symbols.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/symbols.zip"},
+      {"src": "android_release_x64/x86_64_release.pom", "dst": "download.flutter.io/io/flutter/x86_64_release/1.0.0-$engine/x86_64_release-1.0.0-$engine.pom"},
+      {"src": "android_release_x64/x86_64_release.jar", "dst": "download.flutter.io/io/flutter/x86_64_release/1.0.0-$engine/x86_64_release-1.0.0-$engine.jar"},
+      {"src": "android_release_x64/x86_64_release.maven-metadata.xml", "dst": "download.flutter.io/io/flutter/x86_64_release/1.0.0-$engine/x86_64_release-1.0.0-$engine.maven-metadata.xml"}
     ]
   },
   "host": {

--- a/shorebird/ci/shards/macos.json
+++ b/shorebird/ci/shards/macos.json
@@ -136,7 +136,8 @@
     ],
     "compose_input": "macos-framework",
     "artifacts": [
-      {"src": "host_release_arm64/dart-sdk", "dst": "flutter_infra_release/flutter/$engine/dart-sdk-darwin-arm64.zip", "zip": true, "content_hash": true}
+      {"src": "host_release_arm64/dart-sdk", "dst": "flutter_infra_release/flutter/$engine/dart-sdk-darwin-arm64.zip", "zip": true, "content_hash": true},
+      {"src": "mac_release_arm64/zip_archives/darwin-arm64-release/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/artifacts.zip"}
     ]
   },
   "mac-x64": {

--- a/shorebird/ci/shards/windows.json
+++ b/shorebird/ci/shards/windows.json
@@ -9,7 +9,7 @@
       }
     ],
     "artifacts": [
-      {"src": "zip_archives/android-arm64-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/windows-x64.zip"}
+      {"src": "android_release_arm64/zip_archives/android-arm64-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm64-release/windows-x64.zip"}
     ]
   },
   "android-arm32": {
@@ -22,7 +22,7 @@
       }
     ],
     "artifacts": [
-      {"src": "zip_archives/android-arm-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/windows-x64.zip"}
+      {"src": "android_release/zip_archives/android-arm-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-arm-release/windows-x64.zip"}
     ]
   },
   "android-x64": {
@@ -35,7 +35,7 @@
       }
     ],
     "artifacts": [
-      {"src": "zip_archives/android-x64-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/windows-x64.zip"}
+      {"src": "android_release_x64/zip_archives/android-x64-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/windows-x64.zip"}
     ]
   },
   "host": {


### PR DESCRIPTION
## Summary
Pairs with shorebirdtech/_build_engine#209 to make the sharded build
upload the same set of artifacts as the legacy monolithic build.

### compose.json gains \`dst\` + \`artifacts\` per compose
Without these, finalize only uploads shard outputs to prod; the iOS
XCFramework, FlutterMacOS framework + dSYM, and gen_snapshot zips never
leave the staging bucket.

- \`ios-framework\`: artifacts.zip + Flutter.framework.dSYM.zip
- \`macos-framework\`: FlutterMacOS.framework.zip + FlutterMacOS.framework.dSYM.zip
- \`macos-gen-snapshot\`: gen_snapshot.zip, with \`dst: "release/snapshot"\` so
  create_macos_gen_snapshots.py's \`--zip\` flag (which zips the entire dst
  directory) doesn't scoop up sibling composes' outputs

### shards/macos.json: mac-arm64 framework artifact
Adds \`mac_release_arm64/zip_archives/darwin-arm64-release/artifacts.zip\`
uploaded to \`darwin-x64-release/artifacts.zip\` — the deliberate
cross-arch path that legacy mac_upload.sh used (\"arm macs use
darwin-x64-release and we currently only support those\").

## Compatibility
Both fields are optional in the runner parser (defaults: dst=\"release\",
artifacts=[]). Older / mid-rollout flutter SHAs continue to work — the
finalize prod-upload set just shrinks.

## Test plan
- [x] JSON validates
- [ ] After this lands, re-run build_engine end-to-end and confirm the
      compose-uploaded items appear under
      gs://shorebird-build-test/flutter_infra_release/flutter/<sha>/