### PR TITLE
ci(shorebird): produce engine_stamp.json + aot-tools.dill via shell steps

### DIFF
--- a/shorebird/ci/shards/linux.json
+++ b/shorebird/ci/shards/linux.json
@@ -91,6 +91,10 @@
         "gn_args": ["--no-prebuilt-dart-sdk"],
         "ninja_targets": ["flutter/build/archives:artifacts"],
         "out_dir": "host_debug"
+      },
+      {
+        "type": "shell",
+        "command": "mkdir -p out/host_release/aot_tools && out/host_release/dart-sdk/bin/dart pub get --offline --directory=flutter/third_party/dart/pkg/aot_tools && out/host_release/dart-sdk/bin/dart compile kernel flutter/third_party/dart/pkg/aot_tools/bin/aot_tools.dart -o out/host_release/aot_tools/aot-tools.dill"
       }
     ],
     "artifacts": [

--- a/shorebird/ci/shards/macos.json
+++ b/shorebird/ci/shards/macos.json
@@ -157,12 +157,16 @@
         "gn_args": ["--runtime-mode=release", "--mac", "--mac-cpu=x64"],
         "ninja_targets": ["flutter/shell/platform/darwin/macos:zip_macos_flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins", "flutter/build/archives:artifacts"],
         "out_dir": "mac_release"
+      },
+      {
+        "type": "shell",
+        "command": "flutter/bin/et stamp && cp out/engine_stamp.json out/mac_release/engine_stamp.json"
       }
     ],
     "compose_input": "macos-framework",
     "artifacts": [
       {"src": "host_release/dart-sdk", "dst": "flutter_infra_release/flutter/$engine/dart-sdk-darwin-x64.zip", "zip": true, "content_hash": true},
-      {"src": "engine_stamp.json", "dst": "flutter_infra_release/flutter/$engine/engine_stamp.json"}
+      {"src": "mac_release/engine_stamp.json", "dst": "flutter_infra_release/flutter/$engine/engine_stamp.json"}
     ]
   }
 }


### PR DESCRIPTION
## Summary
Pairs with shorebirdtech/_build_engine#209 (which adds a \`shell\` step
type to shard_runner). Closes the last two artifact gaps between the
sharded build and the legacy monolithic build, modulo iOS XCFramework
signing.

### mac-x64: \`flutter/bin/et stamp\`
Legacy mac_build.sh:198 ran \`et stamp\` to write
\`out/engine_stamp.json\`. The new shell step runs \`et stamp\` then
copies the result into \`out/mac_release/engine_stamp.json\` so it
lands in the shard's tarball (which only includes the shard's
out_dir). The artifact src updates accordingly.

### linux/host: \`dart compile kernel ... aot_tools.dart\`
Legacy linux_build.sh:78-90 built \`aot-tools.dill\` from the
just-built host dart-sdk. The new shell step does the same:
\`mkdir -p out/host_release/aot_tools\`, \`dart pub get --offline\` in
the aot_tools package, \`dart compile kernel\` to the artifact path
already declared in the shard's artifacts list.

## Compatibility
Falls flat without shorebirdtech/_build_engine#209 (older shard_runner
doesn't know about \`shell\` step type — would throw at parse time).
So land the build_engine side first, then this.

## Test plan
- [x] JSON validates
- [ ] Trigger sharded build_engine after this lands and a fresh engine
      SHA carries it; confirm both files appear under
      \`gs://shorebird-build-test/.../engine_stamp.json\` and
      \`shorebird/<sha>/aot-tools.dill\`