### PR TITLE
ci(shorebird): drop --offline from aot-tools pub get

### DIFF
--- a/shorebird/ci/shards/linux.json
+++ b/shorebird/ci/shards/linux.json
@@ -94,7 +94,7 @@
       },
       {
         "type": "shell",
-        "command": "mkdir -p out/host_release/aot_tools && out/host_release/dart-sdk/bin/dart pub get --offline --directory=flutter/third_party/dart/pkg/aot_tools && out/host_release/dart-sdk/bin/dart compile kernel flutter/third_party/dart/pkg/aot_tools/bin/aot_tools.dart -o out/host_release/aot_tools/aot-tools.dill"
+        "command": "mkdir -p out/host_release/aot_tools && out/host_release/dart-sdk/bin/dart pub get --directory=flutter/third_party/dart/pkg/aot_tools && out/host_release/dart-sdk/bin/dart compile kernel flutter/third_party/dart/pkg/aot_tools/bin/aot_tools.dart -o out/host_release/aot_tools/aot-tools.dill"
       }
     ],
     "artifacts": [


### PR DESCRIPTION
The legacy linux_build.sh used \`pub get --offline\` because gclient
hooks pre-populated \`~/.pub-cache\` (\`run_pub_get.py\` runs as part of
gclient sync). The new sharded path runs \`run_pub_get.py\` only in the
sync-linux job; per-shard runners have their own ephemeral
\`~/.pub-cache\`, so by the time the shell step runs in linux/host the
aot_tools deps (e.g. very_good_analysis) aren't cached:

\`\`\`
Because aot_tools depends on very_good_analysis any which doesn't
exist (could not find package very_good_analysis in cache),
version solving failed.
\`\`\`

Drop \`--offline\`. pub get will fetch from pub.dev in a few seconds —
trivial overhead vs pre-populating the cache or sharing pub cache via
namespace cache.

Verified failure in [run 25571102939](https://github.com/shorebirdtech/_build_engine/actions/runs/25571102939) (linux/host).