### PR TITLE
Revert #148: restore aot-tools pub get --offline

### DIFF
--- a/shorebird/ci/shards/linux.json
+++ b/shorebird/ci/shards/linux.json
@@ -94,7 +94,7 @@
       },
       {
         "type": "shell",
-        "command": "mkdir -p out/host_release/aot_tools && out/host_release/dart-sdk/bin/dart pub get --directory=flutter/third_party/dart/pkg/aot_tools && out/host_release/dart-sdk/bin/dart compile kernel flutter/third_party/dart/pkg/aot_tools/bin/aot_tools.dart -o out/host_release/aot_tools/aot-tools.dill"
+        "command": "mkdir -p out/host_release/aot_tools && out/host_release/dart-sdk/bin/dart pub get --offline --directory=flutter/third_party/dart/pkg/aot_tools && out/host_release/dart-sdk/bin/dart compile kernel flutter/third_party/dart/pkg/aot_tools/bin/aot_tools.dart -o out/host_release/aot_tools/aot-tools.dill"
       }
     ],
     "artifacts": [


### PR DESCRIPTION
Restores the legacy \`pub get --offline\` form on the aot-tools shell step.

#148 dropped \`--offline\` because the per-shard pub cache wasn't
populated for aot_tools' deps, so the offline resolution failed. That
was a shard-environment problem — sync.yaml runs
\`tools/run_pub_get.py\` to populate the cache, but shards' pub cache is
per-runner ephemeral.

Fixed properly in shorebirdtech/_build_engine#209 (shard-build.yaml
now also runs \`run_pub_get.py\` post-sync), so shell steps can rely on
\`--offline\` matching legacy behavior. The JSON config shouldn't carry
the env-prep detail.

(See FIXME in build_engine's shard-build.yaml: the real fix is to pull
aot_tools deps via gclient like every other in-tree Dart package.)

Land after the build_engine change; before that this would re-break
linux/host the same way #147 did.