### PR TITLE
ci(shorebird): rename macos-framework dst to framework.zip

### DIFF
--- a/shorebird/ci/compose.json
+++ b/shorebird/ci/compose.json
@@ -22,7 +22,7 @@
       "--x64-out-dir": "mac_release"
     },
     "artifacts": [
-      {"src": "FlutterMacOS.framework.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/FlutterMacOS.framework.zip"},
+      {"src": "FlutterMacOS.framework.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/framework.zip"},
       {"src": "FlutterMacOS.framework.dSYM.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64/FlutterMacOS.framework.dSYM.zip"}
     ]
   },


### PR DESCRIPTION
## Summary

`create_macos_framework.py` outputs `FlutterMacOS.framework.zip` locally, but the legacy build uploads it to `.../darwin-x64-release/framework.zip` in the public bucket. The sharded path in `compose.json` was publishing it as `FlutterMacOS.framework.zip`, so the legacy/sharded bucket compare for engine `25c9b21d6` showed:

- only-in-legacy:  `flutter_infra_release/.../darwin-x64-release/framework.zip`
- only-in-sharded: `flutter_infra_release/.../darwin-x64-release/FlutterMacOS.framework.zip`

…for the same underlying artifact. This was the last known-structural divergence between sharded and legacy outputs (the dart-sdk-per-platform collision was the other; fixed in `_build_engine` PR #209). After this lands, remaining bucket-compare diffs should be timestamp/zip-metadata non-determinism only.

`src` stays as `FlutterMacOS.framework.zip` (the actual local filename produced by the compose script); only the published `dst` path changes.

## Test plan
- [ ] After merge, trigger a sharded build on a fresh engine SHA
- [ ] Re-run bucket compare against the legacy output for the same SHA
- [ ] Confirm `darwin-x64-release/framework.zip` is now produced by the sharded build (no `FlutterMacOS.framework.zip` at that path)
- [ ] Confirm the dart-sdk-per-platform sizes differ across darwin/linux/windows