### PR TITLE
ci(shorebird): use framework.zip as macos-framework src (xcframework, not single-arch)

### DIFF
--- a/shorebird/ci/compose.json
+++ b/shorebird/ci/compose.json
@@ -22,7 +22,7 @@
       "--x64-out-dir": "mac_release"
     },
     "artifacts": [
-      {"src": "FlutterMacOS.framework.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/framework.zip"},
+      {"src": "framework.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64-release/framework.zip"},
       {"src": "FlutterMacOS.framework.dSYM.zip", "dst": "flutter_infra_release/flutter/$engine/darwin-x64/FlutterMacOS.framework.dSYM.zip"}
     ]
   },


### PR DESCRIPTION
## Summary

Follow-up to #150. That PR fixed the `dst` path so the macOS framework lands at `darwin-x64-release/framework.zip` (matching legacy). But the `src` was still wrong: we were uploading the single-arch `FlutterMacOS.framework.zip` and renaming it on the way up — same dst name, completely different bytes.

`create_macos_framework.py --zip` produces **two** zips in `dst/`:

- `FlutterMacOS.framework.zip` — single-arch, double-zipped framework (~17 MB)
- `framework.zip` — the **xcframework** (arm64 + x64) plus codesign config files (`entitlements.txt`, `without_entitlements.txt`, `unsigned_binaries.txt`) (~122 MB)

Legacy `mac_upload.sh` uploads the second one. This PR points compose at it.

## Evidence

Bucket compare at `darwin-x64-release/framework.zip`:

| | sharded (post-#150, engine 93865d6024) | legacy (engine 25c9b21d63) |
|---|---|---|
| size | 17,237,143 bytes | 121,918,469 bytes |
| contents | single-arch double-zipped framework | xcframework + codesign config |

The dSYM is unaffected — different src, different dst, sharded matches legacy within 0.01% already.

## Test plan
- [ ] After merge, retrigger sharded build_engine into `gs://shorebird-build-test`
- [ ] Confirm `darwin-x64-release/framework.zip` is now ~122 MB and contains the xcframework structure
- [ ] Confirm dSYM and other artifacts are unchanged