### PR TITLE
shorebird/ci: drop iOS extension-safe shards from the engine build

### DIFF
--- a/shorebird/ci/compose.json
+++ b/shorebird/ci/compose.json
@@ -1,8 +1,8 @@
 {
   "ios-framework": {
-    "requires": ["ios-release", "ios-release-ext", "ios-sim-x64", "ios-sim-x64-ext", "ios-sim-arm64", "ios-sim-arm64-ext"],
+    "requires": ["ios-release", "ios-sim-x64", "ios-sim-arm64"],
     "script": "flutter/sky/tools/create_ios_framework.py",
-    "flags": ["--dsym", "--strip"],
+    "flags": ["--dsym", "--strip", "--no-extension-safe-frameworks"],
     "path_args": {
       "--arm64-out-dir": "ios_release",
       "--simulator-x64-out-dir": "ios_debug_sim",

--- a/shorebird/ci/shards/macos.json
+++ b/shorebird/ci/shards/macos.json
@@ -48,21 +48,6 @@
     ],
     "compose_input": "ios-framework"
   },
-  "ios-release-ext": {
-    "steps": [
-      {
-        "type": "rust",
-        "targets": ["aarch64-apple-ios"]
-      },
-      {
-        "type": "gn_ninja",
-        "gn_args": ["--ios", "--runtime-mode=release", "--darwin-extension-safe", "--xcode-symlinks", "--gn-arg=shorebird_runtime=true"],
-        "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
-        "out_dir": "ios_release_extension_safe"
-      }
-    ],
-    "compose_input": "ios-framework"
-  },
   "ios-sim-x64": {
     "steps": [
       {
@@ -78,21 +63,6 @@
     ],
     "compose_input": "ios-framework"
   },
-  "ios-sim-x64-ext": {
-    "steps": [
-      {
-        "type": "rust",
-        "targets": ["x86_64-apple-ios"]
-      },
-      {
-        "type": "gn_ninja",
-        "gn_args": ["--ios", "--runtime-mode=debug", "--darwin-extension-safe", "--simulator"],
-        "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
-        "out_dir": "ios_debug_sim_extension_safe"
-      }
-    ],
-    "compose_input": "ios-framework"
-  },
   "ios-sim-arm64": {
     "steps": [
       {
@@ -100,17 +70,6 @@
         "gn_args": ["--ios", "--runtime-mode=debug", "--simulator", "--simulator-cpu=arm64"],
         "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
         "out_dir": "ios_debug_sim_arm64"
-      }
-    ],
-    "compose_input": "ios-framework"
-  },
-  "ios-sim-arm64-ext": {
-    "steps": [
-      {
-        "type": "gn_ninja",
-        "gn_args": ["--ios", "--runtime-mode=debug", "--darwin-extension-safe", "--simulator", "--simulator-cpu=arm64"],
-        "ninja_targets": ["flutter/shell/platform/darwin/ios:flutter_framework", "flutter/lib/snapshot:generate_snapshot_bins"],
-        "out_dir": "ios_debug_sim_arm64_extension_safe"
       }
     ],
     "compose_input": "ios-framework"


### PR DESCRIPTION
Removes the three `-ext` shards (`ios-release-ext`, `ios-sim-x64-ext`, `ios-sim-arm64-ext`) from `shorebird/ci/shards/macos.json` and drops them from `ios-framework`'s `requires` in `compose.json`. Adds `--no-extension-safe-frameworks` to the compose flags so `create_ios_framework.py` doesn't try to read the now-missing `*_extension_safe` out_dirs.

## Why this is safe

In upstream PR [flutter/engine#165346](https://github.com/flutter/flutter/pull/165346) ("Make iOS Flutter framework extension-safe", Victoria Ashworth, March 2025), the two-framework design was removed. Before that PR, `BUILD.gn` gated `-fapplication-extension` and `APPLICATION_EXTENSION_API_ONLY=1` on `if (darwin_extension_safe)`. After it, the `ios_application_extension` gn config is applied **unconditionally** to every iOS Flutter framework target. Non-extension-safe API calls are guarded at runtime with `NS_EXTENSION_UNAVAILABLE_IOS` annotations.

In our current engine (post-PR-165346), the gn arg `darwin_extension_safe` is set when `--darwin-extension-safe` is passed but **read by zero `BUILD.gn` files**. Verified:

```
$ grep -rn darwin_extension_safe engine/src
engine/src/flutter/tools/gn:62:  if args.darwin_extension_safe:
engine/src/flutter/tools/gn:839:  if args.darwin_extension_safe:
engine/src/flutter/tools/gn:840:    gn_args['darwin_extension_safe'] = True
```

The only thing the flag still does is append `_extension_safe` to the out_dir. The binaries produced in `ios_release/` and `ios_release_extension_safe/` are byte-identical modulo embedded paths/timestamps.

## Is `extension_safe/` an Apple xcframework standard?

**No** — it's a Flutter convention.

Apple's `.xcframework` format (Xcode 11+) is a single bundle: top-level directory containing per-slice subdirectories (`ios-arm64/`, `ios-arm64_x86_64-simulator/`, `macos-arm64_x86_64/`, ...) plus an `Info.plist` enumerating slices. The spec has no concept of nested or parallel xcframeworks, and `xcodebuild -create-xcframework` doesn't emit anything resembling `extension_safe/`.

Flutter invented the side-by-side pattern: ship `Flutter.xcframework/...` *and* a second, separate xcframework at `extension_safe/Flutter.xcframework/...`, both inside `artifacts.zip`. Two whole xcframeworks, one nested in a subdirectory. After PR #165346 made the runtime guards do the work of restricting non-extension-safe APIs, the parallel ship pattern is purely vestigial — and dropping it violates no Apple format expectation.

## Are we ahead of upstream?

Yes, deliberately. Upstream's direction-of-travel is unambiguous:
- [flutter/engine#165346](https://github.com/flutter/flutter/pull/165346) made the framework unconditionally extension-safe.
- Updated app-extension docs (via discussion in [flutter/engine#142531](https://github.com/flutter/flutter/issues/142531) and [flutter/engine#166546](https://github.com/flutter/flutter/issues/166546)) point users at the main `Flutter.xcframework`, not `extension_safe/`.

But upstream's CI still builds the duplicate (`engine/src/flutter/ci/builders/mac_ios_engine.json` lists `ci/ios_release_extension_safe` etc.) and `create_ios_framework.py` still bundles it into the shipped xcframework by default. [flutter/engine#168955](https://github.com/flutter/flutter/pull/168955) added `--no-extension-safe-frameworks` as an opt-out, used currently only for DDM builds. **No tracking issue exists for the cleanup** — searched flutter/flutter for variants of "remove extension_safe", "deprecate extension safe", "darwin_extension_safe", "stop publishing extension safe", "no-extension-safe-frameworks", "remove FlutterExtensionSafe", and found none beyond the closed parent #142531.

We're paying real macOS CI cost (3 of 9 shards, ~50 min CPU per build, plus the shipped-zip bloat) for upstream's inertia. The direction is in our favor; getting ahead is acceptable.

## What clients see

Customers who manually integrate `Flutter.xcframework` into an Xcode project and pinned `extension_safe/Flutter.xcframework/...` in their project files will need to drop the `extension_safe/` segment and point at `Flutter.xcframework/...` instead. Same bytes; just one less path indirection. The audience is small — Apple's xcframework spec never had this path so it was always Flutter-specific, and Flutter's current docs already point at the unprefixed path.

The Flutter CLI itself does not reference `extension_safe/` anywhere — `grep -rn extension_safe packages/flutter_tools/` returns zero hits. `flutter precache --ios` and `flutter build ios` keep working.

The Shorebird CLI and the artifact_proxy do not reference the path either. The proxy operates on whole-zip URLs (`flutter_infra_release/flutter/$engine/ios-release/artifacts.zip`), not on paths inside the zip, so the absence of `extension_safe/` in the unzipped tree never reaches it.

## If we change our minds

We can restore source-level backwards compatibility with a single symlink in `create_ios_framework.py`:

```python
if args.include_extension_safe_frameworks:
  os.makedirs(os.path.join(dst, 'extension_safe'), exist_ok=True)
  os.symlink('../Flutter.xcframework',
             os.path.join(dst, 'extension_safe', 'Flutter.xcframework'))
```

`sky_utils.create_zip` already uses `zip -y` (symlink-preserving) and macOS `unzip` preserves symlinks on extract. Since `ios-release/artifacts.zip` is only ever pulled on macOS hosts, cross-platform symlink portability isn't a concern. We deliberately picked the simpler path of dropping the duplicate entirely rather than maintaining a fork patch.

## CI impact

Drops 3 of the 9 macOS shards (~50 min of CPU per engine build saved — the macOS slot is the queueing bottleneck since we have only 48 vCPUs / 8 per runner = 6 concurrent slots, so 3 shards always queue today). Ships an `ios-release/artifacts.zip` without the duplicate `extension_safe/Flutter.xcframework` directory (~half the iOS Flutter binary's bytes per release zip).

## Coordinated PR

shorebirdtech/_build_engine needs a matching matrix change to drop the three -ext entries from `build-macos`. Filing that next; both should land together. The configs (this PR) need to be on the engine SHA we build against, so this PR should land first and then we trigger an engine bump that includes it.

## Refs
- [flutter/engine#165346](https://github.com/flutter/flutter/pull/165346) — Make iOS Flutter framework extension-safe
- [flutter/engine#168955](https://github.com/flutter/flutter/pull/168955) — Add --no-extension-safe-frameworks flag
- [flutter/engine#142531](https://github.com/flutter/flutter/issues/142531) — original "nesting bundles disallowed" issue
- [flutter/engine#166546](https://github.com/flutter/flutter/issues/166546) — follow-up on framework-linking docs

## Test plan
- [ ] Trigger a fresh Build Engine workflow_dispatch against shorebird-build-test once the matching _build_engine PR is staged.
- [ ] Confirm the iOS shards drop from 6 to 3, finalize still succeeds, artifacts.zip is smaller.
- [ ] Spot-check that the produced Flutter.xcframework still links cleanly in a sample Shorebird app.
