### PR TITLE
ci(shards): split windows/host into host-release and host-debug

### DIFF
--- a/shorebird/ci/shards/windows.json
+++ b/shorebird/ci/shards/windows.json
@@ -38,7 +38,7 @@
       {"src": "android_release_x64/zip_archives/android-x64-release/windows-x64.zip", "dst": "flutter_infra_release/flutter/$engine/android-x64-release/windows-x64.zip"}
     ]
   },
-  "host": {
+  "host-release": {
     "steps": [
       {
         "type": "rust",
@@ -49,6 +49,18 @@
         "gn_args": ["--runtime-mode=release", "--no-prebuilt-dart-sdk"],
         "ninja_targets": ["dart_sdk", "flutter/build/archives:windows_flutter", "gen_snapshot", "windows", "flutter/build/archives:artifacts"],
         "out_dir": "host_release"
+      }
+    ],
+    "artifacts": [
+      {"src": "host_release/dart-sdk", "dst": "flutter_infra_release/flutter/$engine/dart-sdk-windows-x64.zip", "zip": true, "content_hash": true},
+      {"src": "host_release/zip_archives/windows-x64-release/windows-x64-flutter.zip", "dst": "flutter_infra_release/flutter/$engine/windows-x64-release/windows-x64-flutter.zip"}
+    ]
+  },
+  "host-debug": {
+    "steps": [
+      {
+        "type": "rust",
+        "targets": ["x86_64-pc-windows-msvc"]
       },
       {
         "type": "gn_ninja",
@@ -58,8 +70,6 @@
       }
     ],
     "artifacts": [
-      {"src": "host_release/dart-sdk", "dst": "flutter_infra_release/flutter/$engine/dart-sdk-windows-x64.zip", "zip": true, "content_hash": true},
-      {"src": "host_release/zip_archives/windows-x64-release/windows-x64-flutter.zip", "dst": "flutter_infra_release/flutter/$engine/windows-x64-release/windows-x64-flutter.zip"},
       {"src": "host_debug/zip_archives/windows-x64/artifacts.zip", "dst": "flutter_infra_release/flutter/$engine/windows-x64/artifacts.zip"}
     ]
   }


### PR DESCRIPTION
Tested together with shorebirdtech/_build_engine#231. Hold this PR until #231 is approved or merged so the two can be exercised end-to-end.

## Why

windows/host runs three serial steps inside one matrix job: rust → gn_ninja host_release → gn_ninja host_debug. Recent timings:

- host_release ninja: ~22m
- host_debug ninja: ~18m
- Total wall: ~31m (the long pole on the Windows critical path)

The two ninja steps are mutually independent — they read the same source tree but write to different `out_dir`s and never read each other's outputs. They serialize today only because they're in the same shard.

## What

Split `host` into two parallel sub-shards:

| shard | steps | artifacts |
|---|---|---|
| host-release | rust + gn_ninja host_release | dart-sdk-windows-x64.zip, windows-x64-flutter.zip |
| host-debug   | rust + gn_ninja host_debug   | artifacts.zip |

Rust gets duplicated across both shards (each ninja step links the updater rlib). The duplication is ~1m of CPU per shard but runs in parallel — net wall clock for the longer sub-shard should be roughly half the original.

## Expected impact

windows/host critical path **~31m → ~20m** based on halving the largest ninja phase and adding ~5m of setup duplication.

Windows has slot headroom in the namespace.so pool (4 shards on a runner type configured with more), so adding one shard doesn't queue. `_build_engine`'s GCS source cache (shipping in #231) makes the duplicated setup cost minimal (~1m gclient sync per shard).

## No paired `_build_engine` change needed

shard_runner reads shard configs key-agnostically; the matrix in build_engine.yaml is dynamic via discover-shards. New shard names flow through automatically.

## Test plan

- [ ] Once #231 is approved, trigger an integration test against the test bucket with both branches in play. Confirm windows/host critical path drops from ~31m to ~20m and total wall clock improves by an equivalent amount.