### PR TITLE
shorebird: consume our published Dart SDK on mac-arm64 (skip rebuilding it)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -403,14 +403,25 @@ deps = {
     'dep_type': 'cipd',
     'condition': 'host_os == "mac" and download_dart_sdk'
   },
+  # Consume Shorebird's own published Dart SDK (built from
+  # shorebirdtech/dart-sdk) from GCS instead of Google's CIPD prebuilt, so
+  # the engine builds against our Dart fork and skips rebuilding it from
+  # source (see shards/macos.json: mac-arm64 drops --no-prebuilt-dart-sdk).
+  # Object/sha/size come from the sidecar published alongside the tar.gz at
+  # dart sha 3bc26d9. tar.gz (not zip) so gclient's extraction preserves the
+  # executable bit on bin/dart etc. The bot reads this private bucket via a
+  # keyless-WIF reader SA (shorebirdtech/_build_engine sync.yaml).
   'engine/src/flutter/prebuilts/macos-arm64/dart-sdk': {
-    'packages': [
+    'bucket': 'shorebird-dart-sdk-prebuilt',
+    'objects': [
       {
-        'package': 'flutter/dart-sdk/mac-arm64',
-        'version': 'git_revision:'+Var('dart_revision')
+        'object_name': '3bc26d9ebe7cadc4becd7313cad8cb005f98f6e6/dart-sdk-darwin-arm64.tar.gz',
+        'sha256sum': '5968b313316b9edc8d6b003e9fb663e024568d00cea5efe0214191020412ffbf',
+        'size_bytes': 205230386,
+        'generation': 1780425558083300,
       }
     ],
-    'dep_type': 'cipd',
+    'dep_type': 'gcs',
     'condition': 'host_os == "mac" and download_dart_sdk'
   },
   'engine/src/flutter/prebuilts/windows-x64/dart-sdk': {

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,11 @@ vars = {
   'flutter_git': 'https://flutter.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
-  "dart_sdk_revision": "454bc7108ba4d572809be6a920d3fcb51bed0552",
+  # Our dart-sdk fork revision. Used both for the third_party/dart source
+  # clone (gen_snapshot etc.) and to key the macos-arm64 prebuilt object in
+  # GCS, so source and prebuilt stay the same revision. A published prebuilt
+  # must exist for this sha (see the macos-arm64 dart-sdk gcs dep below).
+  "dart_sdk_revision": "3bc26d9ebe7cadc4becd7313cad8cb005f98f6e6",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
   "updater_rev": "a591b7f6b961430034defe379a8190c41b1c5dbf",
@@ -407,15 +411,17 @@ deps = {
   # shorebirdtech/dart-sdk) from GCS instead of Google's CIPD prebuilt, so
   # the engine builds against our Dart fork and skips rebuilding it from
   # source (see shards/macos.json: mac-arm64 drops --no-prebuilt-dart-sdk).
-  # Object/sha/size come from the sidecar published alongside the tar.gz at
-  # dart sha 3bc26d9. tar.gz (not zip) so gclient's extraction preserves the
-  # executable bit on bin/dart etc. The bot reads this private bucket via a
-  # keyless-WIF reader SA (shorebirdtech/_build_engine sync.yaml).
+  # The object is keyed by Var('dart_sdk_revision') so it tracks the same
+  # fork revision as the source clone above; sha256sum/size_bytes pin the
+  # specific artifact's content and must be updated whenever that revision
+  # bumps. tar.gz (not zip) so gclient's extraction preserves the executable
+  # bit on bin/dart etc. The bot reads this private bucket via a keyless-WIF
+  # reader SA (shorebirdtech/_build_engine sync.yaml).
   'engine/src/flutter/prebuilts/macos-arm64/dart-sdk': {
     'bucket': 'shorebird-dart-sdk-prebuilt',
     'objects': [
       {
-        'object_name': '3bc26d9ebe7cadc4becd7313cad8cb005f98f6e6/dart-sdk-darwin-arm64.tar.gz',
+        'object_name': Var('dart_sdk_revision') + '/dart-sdk-darwin-arm64.tar.gz',
         'sha256sum': '5968b313316b9edc8d6b003e9fb663e024568d00cea5efe0214191020412ffbf',
         'size_bytes': 205230386,
         'generation': 1780425558083300,

--- a/shorebird/ci/shards/macos.json
+++ b/shorebird/ci/shards/macos.json
@@ -82,7 +82,7 @@
       },
       {
         "type": "gn_ninja",
-        "gn_args": ["--runtime-mode=release", "--mac-cpu=arm64", "--no-prebuilt-dart-sdk"],
+        "gn_args": ["--runtime-mode=release", "--mac-cpu=arm64"],
         "ninja_targets": ["dart_sdk"],
         "out_dir": "host_release_arm64"
       },


### PR DESCRIPTION
## What

Two changes, both scoped to **mac-arm64**:
1. `DEPS`: point the `macos-arm64` dart-sdk prebuilt at Shorebird's own published SDK (`gs://shorebird-dart-sdk-prebuilt`, `dep_type: gcs`) instead of Google's CIPD.
2. `shorebird/ci/shards/macos.json`: drop `--no-prebuilt-dart-sdk` from the `mac-arm64` shard.

## Why — build time

The `mac-arm64` shard currently **builds the Dart SDK from source** (`--no-prebuilt-dart-sdk` + `ninja dart_sdk`). Dropping that flag turns `dart_sdk` into `copy_dart_sdk` — a **~1.5s copy** of the prebuilt instead of a full from-source compile. So the engine now:
- builds against **our** Dart fork end to end (the prebuilt is our SDK), and
- skips rebuilding Dart on mac-arm64 → **significantly shorter shard time**.

The published `dart-sdk-darwin-arm64.zip` engine artifact is now our SDK (the copy), so downstream consumers are unchanged.

## How to evaluate

- **Correctness:** an engine build at this revision should produce a working mac-arm64 engine + framework; the `dart-sdk-darwin-arm64.zip` artifact's `revision` should be our published dart sha.
- **Speed:** compare the `mac-arm64` shard wall/CPU time against a baseline build — the from-source `dart_sdk` step should be gone, replaced by a ~seconds copy.

## Verified locally

`gn --runtime-mode=release --mac-cpu=arm64 --prebuilt-dart-sdk` + `ninja dart_sdk` → `copy_dart_sdk` copies our SDK (`revision 3bc26d9`, `bin/dart` executable, `3.12.1`) in ~1.5s. The full consume path (authenticated private GCS fetch → extract → gn uses our Dart → our Dart compiles the platform kernel) was confirmed end to end.

## Sequencing (important)

**Merge the `_build_engine` reader-auth PR first** (shorebirdtech/_build_engine#240). Once DEPS points at the private bucket, `gclient sync` needs the keyless-WIF reader credential; without #240 a mac-arm64 build would hit `401 anonymous` at sync. mac-x64/linux/windows are untouched (still Google CIPD / from-source) pending their own published prebuilts.

Depends on: shorebirdtech/_build_engine#240. Reader infra: shorebirdtech/_shorebird#2277 (merged). Broader WIF migration: shorebirdtech/_shorebird#2276.