### PR TITLE
ci: pull upstream's fixed freeze.yml (broken YAML on stable)

### DIFF
--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -20,16 +20,14 @@ jobs:
     name: Check Code Freeze
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'flutter/flutter' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
+    steps:
       - name: Check for changes in frozen folders
+        if: github.event_name != 'merge_group'
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          token: ${{ github.token }}
           filters: |
             frozen:
               - 'packages/flutter/lib/src/material/**'
@@ -46,27 +44,9 @@ jobs:
               - 'packages/flutter/test_fixes/cupertino/**'
 
       - name: Fail on frozen changes
-        # This step only runs if the 'frozen' filter matched AND the override label is NOT present
-        if: |
-          steps.filter.outputs.frozen == 'true' &&
-          !contains(github.event.pull_request.labels.*.name, 'override: code freeze')
+        if: github.event_name != 'merge_group' && steps.filter.outputs.frozen == 'true' && !contains(github.event.pull_request.labels.*.name, 'override code freeze')
         run: |
           echo "Error: Code changes detected during the current code freeze."
-          echo "The following paths are currently frozen:"
-          echo "  - packages/flutter/lib/src/material/"
-          echo "  - packages/flutter/lib/src/cupertino/"
-          echo "  - (and associated tests/examples)"
-          echo ""
-          echo "If this is a critical fix that must land during the freeze, please file an issue for team-design."
-          echo "Information on this code freeze: https://github.com/flutter/flutter/issues/184093"
+          echo "If this is a critical fix that must land, please file an issue for team-design."
+          echo "Info: https://github.com/flutter/flutter/issues/184093"
           exit 1
-
-      - name: Pass if overridden
-        if: |
-          steps.filter.outputs.frozen == 'true' &&
-          contains(github.event.pull_request.labels.*.name, 'override: code freeze')
-        run: echo "Code freeze overridden by override: code freeze label."
-
-      - name: Pass if no frozen changes
-        if: steps.filter.outputs.frozen == 'false'
-        run: echo "No changes to frozen code."


### PR DESCRIPTION
## What

Replace `.github/workflows/freeze.yml` with upstream flutter/flutter's current version.

## Why

The copy synced into `shorebird/dev` is **broken YAML**: line 68's `run: echo "...override: code freeze..."` makes the parser read the `: ` as a mapping key (`mapping values are not allowed here`, line 68 col 54). As a result the workflow fails to parse and reports a **failed run on every push** to `shorebird/dev` (visible 06-01, 06-02, …) — including on unrelated PRs.

We never modified this file (it's upstream-owned). Upstream has since fixed it (dropped the colon-bearing label + the offending steps). Pulling their current version:
- makes it parse → stops the per-push red, and
- keeps the file aligned with upstream, so it won't conflict on the next sync (vs. deleting it, which upstream would just re-add).

It remains gated to `github.repository == 'flutter/flutter'`, so it's still a **no-op on our fork** — this is purely fixing the parse failure.

Verified: `python -c 'yaml.safe_load(...)'` passes on the new file. Unrelated to (but unblocks the CI noise on) the dart-sdk consumption PR #155.